### PR TITLE
fix: backfill script lee MONGODB_URI (nombre real del proyecto)

### DIFF
--- a/backend/scripts/backfill-media-dimensions.js
+++ b/backend/scripts/backfill-media-dimensions.js
@@ -20,9 +20,9 @@ const sharp = require('sharp');
 const DRY_RUN = process.argv.includes('--dry');
 
 async function main() {
-  const uri = process.env.MONGO_URI;
+  const uri = process.env.MONGODB_URI || process.env.MONGO_URI;
   if (!uri) {
-    throw new Error('MONGO_URI is not set — run this inside the backend container');
+    throw new Error('MONGODB_URI is not set — run this inside the backend container');
   }
 
   await mongoose.connect(uri);


### PR DESCRIPTION
## Summary
- El script `backend/scripts/backfill-media-dimensions.js` chequeaba `MONGO_URI`, pero el container backend expone la variable como `MONGODB_URI`
- Ahora prioriza `MONGODB_URI` y mantiene `MONGO_URI` como fallback
- Evita el workaround `MONGO_URI=\$MONGODB_URI ...` al ejecutar

## Contexto
Detectado al ejecutar el backfill en prod hoy (61 docs migrados via workaround inline).

## Test plan
- [x] Backfill ejecutado en prod con workaround (61 ok / 0 fail)
- [ ] Tras merge + rebuild backend, re-ejecutar `--dry`: debe arrojar 0 docs (idempotencia)