### PR TITLE
feat: usar width/height en componentes de galería (anti layout shift)

### DIFF
--- a/frontend/src/components/AlbumCarousel.tsx
+++ b/frontend/src/components/AlbumCarousel.tsx
@@ -6,6 +6,8 @@ interface Image {
   url: string;
   alt: string;
   description?: string;
+  width?: number;
+  height?: number;
 }
 
 interface AlbumCarouselProps {
@@ -131,8 +133,8 @@ export default function AlbumCarousel({ images, albumTitle }: AlbumCarouselProps
       <div className="relative aspect-video bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden">
         <a
           href={getOriginalImageUrl(currentImage.url)}
-          data-pswp-width={1920}
-          data-pswp-height={1080}
+          data-pswp-width={currentImage.width || 1920}
+          data-pswp-height={currentImage.height || 1080}
           target="_blank"
           rel="noopener noreferrer"
           className="block w-full h-full"
@@ -143,6 +145,8 @@ export default function AlbumCarousel({ images, albumTitle }: AlbumCarouselProps
           <img
             src={getOptimizedImageUrl(currentImage.url, 2560, 95)}
             alt={currentImage.alt}
+            width={currentImage.width}
+            height={currentImage.height}
             className="w-full h-full object-contain"
             loading="lazy"
             onError={(e) => {

--- a/frontend/src/components/AlbumGrid.tsx
+++ b/frontend/src/components/AlbumGrid.tsx
@@ -69,6 +69,8 @@ export default function AlbumGrid({ images, albumTitle }: AlbumGridProps) {
               <img
                 src={getOptimizedImageUrl(image.url, 600, 90)}
                 alt={image.alt}
+                width={image.width}
+                height={image.height}
                 className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                 loading="lazy"
                 onError={(e) => {

--- a/frontend/src/components/InstagramModal.tsx
+++ b/frontend/src/components/InstagramModal.tsx
@@ -121,6 +121,8 @@ export default function InstagramModal({
           <img
             src={getOriginalImageUrl(currentImage.url)}
             alt={currentImage.alt}
+            width={currentImage.width}
+            height={currentImage.height}
             className={`max-w-full max-h-full object-contain transition-opacity duration-300 ${
               imageLoaded ? 'opacity-100' : 'opacity-0'
             }`}

--- a/frontend/src/components/misc/ImageWrapper.astro
+++ b/frontend/src/components/misc/ImageWrapper.astro
@@ -7,13 +7,15 @@ interface Props {
   alt?: string
   position?: string
   basePath?: string
+  width?: number
+  height?: number
 }
 import { Image } from 'astro:assets'
 import { url } from '../../utils/url-utils'
 import { getBackendResourceUrl } from '../../lib/env'
 import { getOptimizedImageUrl } from '../../lib/image-utils'
 
-const { id, src, alt, position = 'center', basePath = '/' } = Astro.props
+const { id, src, alt, position = 'center', basePath = '/', width, height } = Astro.props
 const className = Astro.props.class
 
 let isLocal = !(
@@ -52,6 +54,6 @@ const imageStyle = `object-position: ${position}`
 <div id={id} class:list={[className, 'overflow-hidden relative']}>
     <div class="transition absolute inset-0 dark:bg-black/10 bg-opacity-50 pointer-events-none"></div>
     {isLocal && img && <Image src={img} alt={alt || ""} class={imageClass} style={imageStyle} format="webp" quality={80} loading="lazy" />}
-    {!isLocal && <img src={isBackendResource ? getOptimizedImageUrl(src, 1200, 90) : isPublic ? url(src) : src} alt={alt || ""} class={imageClass} style={imageStyle} loading="lazy" />}
+    {!isLocal && <img src={isBackendResource ? getOptimizedImageUrl(src, 1200, 90) : isPublic ? url(src) : src} alt={alt || ""} class={imageClass} style={imageStyle} loading="lazy" width={width} height={height} />}
 </div>
 


### PR DESCRIPTION
## Summary
Aprovecha las dimensiones que el backend ya persiste en cada media (PR anterior) para que el browser reserve el espacio correcto antes de descargar la imagen. Mejora CLS y UX en galería pública y lightbox.

### Cambios por componente

- **AlbumCarousel.tsx**: agrega \`width\`/\`height\` a la interface \`Image\`, reemplaza \`data-pswp-width=1920\` / \`data-pswp-height=1080\` **hardcoded** por las dimensiones reales (con fallback). Esto arregla un bug visible: fotos verticales se abrían mal proporcionadas en el lightbox de PhotoSwipe.
- **AlbumGrid.tsx**: pasa \`width\`/\`height\` al \`<img>\` del bento grid (ya tenía los datos en la interface, solo faltaba propagarlos al DOM).
- **InstagramModal.tsx**: pasa \`width\`/\`height\` al \`<img>\` del modal — fix CLS visible al abrir el modal sobre una foto.
- **ImageWrapper.astro**: acepta \`width\`/\`height\` opcionales y los propaga al \`<img>\` remoto. Habilita el mismo comportamiento para covers de blog y cualquier futuro caller.

## Pre-requisitos cumplidos
- Backend ya popula \`width\`/\`height\` al subir nuevos medias (commit \`d2f1245\`).
- Backfill ejecutado en prod: 61 docs históricos con dimensiones.
- \`gallery/[slug].astro\` ya extraía y mapeaba \`image.width\` / \`image.height\` a los componentes.

## Test plan
- [x] \`pnpm build\` en \`frontend/\` pasa sin errores.
- [ ] Tras merge + deploy: abrir un álbum en bfmu.dev/gallery, verificar que la página no salte al cargar imágenes (DevTools → Performance → Layout shifts).
- [ ] Abrir el modal sobre una foto vertical: el lightbox de PhotoSwipe ahora respeta la orientación real (no se ve aplastada).
- [ ] Lighthouse CLS en \`/gallery/<slug>\`: comparar antes/después.