### PR TITLE
feat(gallery): rediseño AlbumCard — info visible + mini-mosaico + CTA

### DIFF
--- a/frontend/src/components/AlbumCard.astro
+++ b/frontend/src/components/AlbumCard.astro
@@ -17,50 +17,102 @@ interface Props {
 
 const { album } = Astro.props;
 
-const imageCount = Array.isArray(album.images) ? album.images.length : 0;
-const coverUrl = album.coverImage || (album.images && album.images.length > 0 && typeof album.images[0] !== 'string' ? album.images[0].url : null) || '/default-avatar.svg';
+const imageObjs = (Array.isArray(album.images) ? album.images : []).filter(
+  (img: any) => img && typeof img === 'object' && img.url,
+);
 
-// Construir URL optimizada de la imagen
-function getImageUrl(imgUrl: string | undefined): string {
-  if (!imgUrl) return '/default-avatar.svg';
-  return getOptimizedImageUrl(imgUrl, 400);
+const imageCount = imageObjs.length;
+
+const coverRaw = album.coverImage || (imageObjs[0]?.url ?? null);
+
+// Thumbs: hasta 3, distintas a la cover
+const extras = imageObjs
+  .filter((img: any) => img.url !== coverRaw)
+  .slice(0, 3);
+
+function thumbUrl(src: string | undefined, w: number) {
+  if (!src) return '/default-avatar.svg';
+  return getOptimizedImageUrl(src, w, 80);
 }
 
-const fullCoverUrl = getImageUrl(coverUrl);
+const coverUrl = thumbUrl(coverRaw ?? undefined, 600);
 const albumUrl = url(`/gallery/${album.slug}`);
+
+const dateLabel = album.publishedAt
+  ? new Date(album.publishedAt).toLocaleDateString('es-ES', {
+      year: 'numeric',
+      month: 'short',
+    })
+  : null;
+
+const showMosaic = extras.length > 0;
 ---
 
-<a href={albumUrl} class="group block relative aspect-square rounded-lg overflow-hidden bg-gray-100 dark:bg-gray-800 hover:shadow-xl transition-all duration-300">
-    <img
-        src={fullCoverUrl}
+<a
+  href={albumUrl}
+  class="group flex flex-col rounded-lg overflow-hidden bg-[var(--card-bg)] border border-black/5 dark:border-white/5 transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+>
+  <!-- Image area: cover + mini-mosaic stack -->
+  <div class="relative aspect-square flex bg-gray-100 dark:bg-gray-800 overflow-hidden">
+    <!-- Main cover -->
+    <div class={`relative overflow-hidden ${showMosaic ? 'w-2/3' : 'w-full'}`}>
+      <img
+        src={coverUrl}
         alt={album.title}
-        class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-110"
+        class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
         loading="lazy"
         onerror="this.onerror=null; this.src='/default-avatar.svg'"
-    />
-    <!-- Overlay con información -->
-    <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-        <div class="absolute bottom-0 left-0 right-0 p-4 text-white">
-            <h3 class="text-lg font-semibold mb-1">
-                {album.title}
-            </h3>
-            {album.description && (
-                <p class="text-sm text-white/90 line-clamp-2 mb-2">
-                    {album.description}
-                </p>
-            )}
-            <div class="flex items-center gap-3 text-xs text-white/80">
-                <span>{imageCount} imagen{imageCount !== 1 ? 'es' : ''}</span>
-                {album.publishedAt && (
-                    <span>
-                        {new Date(album.publishedAt).toLocaleDateString('es-ES', {
-                            year: 'numeric',
-                            month: 'short'
-                        })}
-                    </span>
-                )}
-            </div>
-        </div>
+      />
     </div>
-</a>
 
+    {showMosaic && (
+      <div class="w-1/3 flex flex-col gap-[2px] ml-[2px]">
+        {extras.map((img: any) => (
+          <div class="flex-1 relative overflow-hidden">
+            <img
+              src={thumbUrl(img.url, 200)}
+              alt=""
+              class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+              loading="lazy"
+              onerror="this.onerror=null; this.src='/default-avatar.svg'"
+            />
+          </div>
+        ))}
+        {Array.from({ length: Math.max(0, 3 - extras.length) }).map(() => (
+          <div class="flex-1 bg-gray-100 dark:bg-gray-800"></div>
+        ))}
+      </div>
+    )}
+
+    <!-- Photo count badge -->
+    {imageCount > 0 && (
+      <div class="absolute top-2 right-2 px-2 py-1 rounded-md bg-black/60 backdrop-blur-sm text-white text-xs font-medium flex items-center gap-1">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-3 h-3">
+          <path fill-rule="evenodd" d="M1 5.25A2.25 2.25 0 013.25 3h13.5A2.25 2.25 0 0119 5.25v9.5A2.25 2.25 0 0116.75 17H3.25A2.25 2.25 0 011 14.75v-9.5zm1.5 5.81v3.69c0 .414.336.75.75.75h13.5a.75.75 0 00.75-.75v-2.69l-2.22-2.219a.75.75 0 00-1.06 0l-1.91 1.909.47.47a.75.75 0 11-1.06 1.06L6.53 8.091a.75.75 0 00-1.06 0l-2.97 2.97zM12 7a1 1 0 11-2 0 1 1 0 012 0z" clip-rule="evenodd" />
+        </svg>
+        {imageCount}
+      </div>
+    )}
+  </div>
+
+  <!-- Text area: always visible -->
+  <div class="px-3 py-3 md:px-4 md:py-3 flex flex-col gap-1">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class="text-sm md:text-base font-semibold text-gray-900 dark:text-white truncate">
+        {album.title}
+      </h3>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        class="w-4 h-4 text-gray-400 dark:text-gray-500 flex-shrink-0 transition-transform duration-300 group-hover:translate-x-1 group-hover:text-[var(--primary)]"
+      >
+        <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd" />
+      </svg>
+    </div>
+    <div class="text-xs text-gray-500 dark:text-gray-400">
+      <span>{imageCount} {imageCount === 1 ? 'foto' : 'fotos'}</span>
+      {dateLabel && <span> · {dateLabel}</span>}
+    </div>
+  </div>
+</a>


### PR DESCRIPTION
## Problema
La gente entra a \`/gallery\` pero **no abre los álbumes**. Diagnóstico:
1. Toda la info textual (título, count, fecha) estaba detrás de \`opacity-0 group-hover:opacity-100\` → en mobile la card era una imagen sin contexto.
2. Solo se veía la cover (1 foto). No comunicaba "hay 36 fotos adentro".
3. CTA implícito (la card es clickable pero nada lo dice).

## Solución (combo A+B+D)

### A. Info siempre visible
Título, count y fecha bajaron al área de texto debajo de la imagen — visibles también en mobile.

### B. Mini-mosaico en vez de cover sola
Cuando el álbum tiene 2+ fotos, la card muestra cover (2/3 ancho) + stack de hasta 3 thumbs (1/3 ancho). Comunica visualmente que hay más adentro.

### D. CTA + microinteracciones
- Badge con número de fotos arriba a la derecha sobre la imagen.
- Flecha \`→\` siempre visible, se traslada y tiñe \`var(--primary)\` en hover.
- Hover: lift (\`-translate-y-1\`) + \`shadow-xl\` + scale sutil en imágenes.

## Layout

\`\`\`
┌─────────────────────────┐
│ ┌──────────┬──┬──┬──┐   │
│ │          │t1│t2│t3│   │  ← cover + 3 thumbs
│ │  cover   │  │  │  │   │
│ │          │  │  │  │   │
│ └──────────┴──┴──┴──┘   │
│ Título del álbum    →   │  ← visible siempre
│ 36 fotos · Mar 2026     │
└─────────────────────────┘
\`\`\`

## Test plan
- [x] \`pnpm build\` pasa.
- [ ] Tras deploy: abrir \`/gallery/\` en desktop y mobile (DevTools).
- [ ] Verificar que título + count + fecha se ven sin hover.
- [ ] Verificar que álbumes con 1 foto se ven bien (sin mosaico, cover full).
- [ ] Verificar que álbumes con 2-3 fotos rellenan los huecos del stack.
- [ ] Verificar hover: card se levanta, flecha se mueve.