### PR TITLE
fix(media): rotación visible end-to-end + cache sano (ETag + version buster)

### DIFF
--- a/backend/src/media/media.controller.ts
+++ b/backend/src/media/media.controller.ts
@@ -16,8 +16,10 @@ import {
   HttpStatus,
   Logger,
   StreamableFile,
-  Header,
+  Headers,
+  Res,
 } from '@nestjs/common';
+import type { Response } from 'express';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiTags,
@@ -176,15 +178,17 @@ export class MediaController {
   @ApiQuery({ name: 'h', required: false, description: 'Alto máximo en píxeles' })
   @ApiQuery({ name: 'q', required: false, description: 'Calidad 1-100 (default: 80)' })
   @ApiQuery({ name: 'format', required: false, description: 'webp | jpeg' })
+  @ApiQuery({ name: 'v', required: false, description: 'Cache buster (típicamente la orientación)' })
   @ApiResponse({ status: 200, description: 'Imagen optimizada' })
-  @Header('Cache-Control', 'public, max-age=31536000, immutable')
   async serve(
     @Query('path') pathParam: string,
+    @Res({ passthrough: true }) res: Response,
     @Query('w') w?: string,
     @Query('h') h?: string,
     @Query('q') q?: string,
     @Query('format') formatParam?: string,
-  ): Promise<StreamableFile> {
+    @Headers('if-none-match') ifNoneMatch?: string,
+  ): Promise<StreamableFile | undefined> {
     if (!pathParam || typeof pathParam !== 'string') {
       throw new BadRequestException('El parámetro path es requerido');
     }
@@ -207,16 +211,32 @@ export class MediaController {
     const quality = Math.min(100, Math.max(1, parseInt(q || '80', 10)));
     const outputFormat = formatParam === 'jpeg' ? 'jpeg' : 'webp';
 
+    // Buscar orientación guardada del usuario (si existe registro en media)
+    const mediaRecord = await this.mediaService.findByPath(cleanPath);
+    const userOrientation = mediaRecord?.orientation ?? 0;
+
+    // ETag basado en lo que afecta el output. Si rotás en admin, userOrientation cambia → ETag
+    // cambia → cache invalidado automáticamente sin importar lo que tenga el browser/proxy.
+    const etag = `W/"${cleanPath}-${userOrientation}-${width ?? 0}-${height ?? 0}-${quality}-${outputFormat}"`;
+
+    // Cache largo PERO sin `immutable` (la imagen SÍ puede cambiar al rotarla).
+    // El frontend bustea con &v=<orientation> para forzar URL nueva ante cambios.
+    res.setHeader('Cache-Control', 'public, max-age=2592000, stale-while-revalidate=86400');
+    res.setHeader('ETag', etag);
+    res.setHeader('Vary', 'Accept');
+
+    if (ifNoneMatch && ifNoneMatch === etag) {
+      res.status(304);
+      return undefined;
+    }
+
     if (ext === '.svg') {
       const buffer = fs.readFileSync(fullPath);
+      res.setHeader('Content-Type', 'image/svg+xml');
       return new StreamableFile(buffer, { type: 'image/svg+xml' });
     }
 
     try {
-      // Buscar orientación guardada del usuario (si existe registro en media)
-      const mediaRecord = await this.mediaService.findByPath(cleanPath);
-      const userOrientation = mediaRecord?.orientation ?? 0;
-
       let pipeline = sharp(fullPath)
         .rotate(); // Sin argumentos aplica EXIF orientation (equivale a autoOrient)
       if (userOrientation) {
@@ -233,6 +253,7 @@ export class MediaController {
         ? await pipeline.webp({ quality }).toBuffer()
         : await pipeline.jpeg({ quality }).toBuffer();
       const mimeType = outputFormat === 'webp' ? 'image/webp' : 'image/jpeg';
+      res.setHeader('Content-Type', mimeType);
       return new StreamableFile(buffer, { type: mimeType });
     } catch (err) {
       this.logger.warn(`Error processing image ${cleanPath}: ${err}`);

--- a/frontend/src/components/AlbumCard.astro
+++ b/frontend/src/components/AlbumCard.astro
@@ -23,19 +23,21 @@ const imageObjs = (Array.isArray(album.images) ? album.images : []).filter(
 
 const imageCount = imageObjs.length;
 
-const coverRaw = album.coverImage || (imageObjs[0]?.url ?? null);
+const coverObj = imageObjs.find((img: any) => img.url === album.coverImage) ?? imageObjs[0] ?? null;
+const coverRaw = album.coverImage || (coverObj?.url ?? null);
+const coverOrientation = coverObj?.orientation ?? 0;
 
 // Thumbs: hasta 3, distintas a la cover
 const extras = imageObjs
   .filter((img: any) => img.url !== coverRaw)
   .slice(0, 3);
 
-function thumbUrl(src: string | undefined, w: number) {
+function thumbUrl(src: string | undefined, w: number, version?: number) {
   if (!src) return '/default-avatar.svg';
-  return getOptimizedImageUrl(src, w, 80);
+  return getOptimizedImageUrl(src, w, 80, version ?? 0);
 }
 
-const coverUrl = thumbUrl(coverRaw ?? undefined, 600);
+const coverUrl = thumbUrl(coverRaw ?? undefined, 600, coverOrientation);
 const albumUrl = url(`/gallery/${album.slug}`);
 
 const dateLabel = album.publishedAt
@@ -70,7 +72,7 @@ const showMosaic = extras.length > 0;
         {extras.map((img: any) => (
           <div class="flex-1 relative overflow-hidden">
             <img
-              src={thumbUrl(img.url, 200)}
+              src={thumbUrl(img.url, 200, img.orientation ?? 0)}
               alt=""
               class="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
               loading="lazy"

--- a/frontend/src/components/AlbumCarousel.tsx
+++ b/frontend/src/components/AlbumCarousel.tsx
@@ -8,6 +8,7 @@ interface Image {
   description?: string;
   width?: number;
   height?: number;
+  orientation?: number;
 }
 
 interface AlbumCarouselProps {
@@ -132,7 +133,7 @@ export default function AlbumCarousel({ images, albumTitle }: AlbumCarouselProps
       {/* Main Image */}
       <div className="relative aspect-video bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden">
         <a
-          href={getOriginalImageUrl(currentImage.url)}
+          href={getOriginalImageUrl(currentImage.url, currentImage.orientation ?? 0)}
           data-pswp-width={currentImage.width || 1920}
           data-pswp-height={currentImage.height || 1080}
           target="_blank"
@@ -143,7 +144,7 @@ export default function AlbumCarousel({ images, albumTitle }: AlbumCarouselProps
           onTouchEnd={handleTouchEnd}
         >
           <img
-            src={getOptimizedImageUrl(currentImage.url, 2560, 95)}
+            src={getOptimizedImageUrl(currentImage.url, 2560, 95, currentImage.orientation ?? 0)}
             alt={currentImage.alt}
             width={currentImage.width}
             height={currentImage.height}
@@ -231,7 +232,7 @@ export default function AlbumCarousel({ images, albumTitle }: AlbumCarouselProps
               aria-label={`Ver imagen ${index + 1}`}
             >
               <img
-                src={getOptimizedImageUrl(image.url, 160)}
+                src={getOptimizedImageUrl(image.url, 160, 80, image.orientation ?? 0)}
                 alt={image.alt}
                 className="w-full h-full object-cover"
                 loading="lazy"

--- a/frontend/src/components/AlbumGrid.tsx
+++ b/frontend/src/components/AlbumGrid.tsx
@@ -9,6 +9,7 @@ interface Image {
   description?: string;
   width?: number;
   height?: number;
+  orientation?: number;
 }
 
 interface AlbumGridProps {
@@ -67,7 +68,7 @@ export default function AlbumGrid({ images, albumTitle }: AlbumGridProps) {
               className={`group relative overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800 ${sizeClass} cursor-pointer`}
             >
               <img
-                src={getOptimizedImageUrl(image.url, 600, 90)}
+                src={getOptimizedImageUrl(image.url, 600, 90, image.orientation ?? 0)}
                 alt={image.alt}
                 width={image.width}
                 height={image.height}

--- a/frontend/src/components/InstagramModal.tsx
+++ b/frontend/src/components/InstagramModal.tsx
@@ -9,6 +9,7 @@ interface Image {
   description?: string;
   width?: number;
   height?: number;
+  orientation?: number;
 }
 
 interface InstagramModalProps {
@@ -119,7 +120,7 @@ export default function InstagramModal({
             </div>
           )}
           <img
-            src={getOriginalImageUrl(currentImage.url)}
+            src={getOriginalImageUrl(currentImage.url, currentImage.orientation ?? 0)}
             alt={currentImage.alt}
             width={currentImage.width}
             height={currentImage.height}

--- a/frontend/src/components/admin/MediaLibrary.tsx
+++ b/frontend/src/components/admin/MediaLibrary.tsx
@@ -10,7 +10,7 @@ import {
   type MediaQuery,
 } from '../../lib/admin-api';
 import { getOptimizedImageUrl, getOriginalImageUrl } from '../../lib/image-utils';
-import { showSuccess, showError } from '@/lib/notifications';
+import { showSuccess, showError, showInfo } from '@/lib/notifications';
 
 export default function MediaLibrary() {
   const [media, setMedia] = useState<MediaFile[]>([]);
@@ -139,21 +139,40 @@ export default function MediaLibrary() {
   };
 
   const getImageUrl = (media: MediaFile): string => {
-    const base = getOptimizedImageUrl(media.url, 200);
-    return media.orientation ? `${base}&_o=${media.orientation}` : base;
+    return getOptimizedImageUrl(media.url, 200, 80, media.orientation ?? 0);
   };
 
   const handleRotate = async (degrees: number) => {
-    if (!selectedMedia) return;
+    if (!selectedMedia) {
+      showError('No hay imagen seleccionada');
+      return;
+    }
+    if (!selectedMedia._id) {
+      showError('Imagen sin ID válido');
+      console.error('[handleRotate] selectedMedia sin _id', selectedMedia);
+      return;
+    }
     const current = selectedMedia.orientation ?? 0;
     const newOrientation = ((current + degrees) % 360 + 360) % 360;
+    console.log('[handleRotate] start', {
+      id: selectedMedia._id,
+      filename: selectedMedia.filename,
+      current,
+      degrees,
+      newOrientation,
+    });
+    showInfo(`Rotando ${degrees > 0 ? '+' : ''}${degrees}°...`);
     try {
-      await updateMedia(selectedMedia._id, { orientation: newOrientation });
-      showSuccess('Orientación actualizada');
-      setSelectedMedia({ ...selectedMedia, orientation: newOrientation });
+      const updated = await updateMedia(selectedMedia._id, { orientation: newOrientation });
+      console.log('[handleRotate] success', { id: updated._id, orientation: updated.orientation });
+      showSuccess(`Orientación actualizada (${updated.orientation ?? newOrientation}°)`);
+      // Confiar en la respuesta del backend en lugar del state local con spread.
+      setSelectedMedia(updated);
       loadMedia();
     } catch (error: any) {
-      showError(error.message || 'Error al rotar imagen');
+      console.error('[handleRotate] failed', error);
+      const detail = error?.message || error?.data?.message || 'desconocido';
+      showError(`Error al rotar: ${detail}`);
     }
   };
 
@@ -291,7 +310,7 @@ export default function MediaLibrary() {
 
               <img
                 key={`${selectedMedia._id}-${selectedMedia.orientation ?? 0}`}
-                src={`${getOriginalImageUrl(selectedMedia.url)}&_o=${selectedMedia.orientation ?? 0}`}
+                src={getOriginalImageUrl(selectedMedia.url, selectedMedia.orientation ?? 0)}
                 alt={selectedMedia.alt || selectedMedia.originalName}
                 className="w-full rounded-lg mb-4"
               />

--- a/frontend/src/components/home/GalleryPreview.astro
+++ b/frontend/src/components/home/GalleryPreview.astro
@@ -28,9 +28,9 @@ try {
   console.error('[GalleryPreview] Error al obtener álbumes:', e);
 }
 
-function getImageUrl(url: string | undefined): string {
+function getImageUrl(url: string | undefined, version?: number): string {
   if (!url) return '/default-avatar.svg';
-  return getOptimizedImageUrl(url, 400);
+  return getOptimizedImageUrl(url, 400, 80, version ?? 0);
 }
 ---
 
@@ -42,10 +42,12 @@ function getImageUrl(url: string | undefined): string {
       <div class="mt-8 max-w-5xl mx-auto px-6">
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
           {albums.slice(0, 4).map((album) => {
-            const cover = album.coverImage ?? (Array.isArray(album.images) && album.images[0] && typeof album.images[0] === 'object' && album.images[0] !== null && 'url' in (album.images[0] as object))
-              ? ((album.images[0] as { url: string }).url)
+            const firstImg = Array.isArray(album.images) && album.images[0] && typeof album.images[0] === 'object' && album.images[0] !== null
+              ? (album.images[0] as { url?: string; orientation?: number })
               : null;
-            const coverUrl = getImageUrl(cover ?? undefined);
+            const cover = album.coverImage ?? firstImg?.url ?? null;
+            const coverOrientation = firstImg?.orientation ?? 0;
+            const coverUrl = getImageUrl(cover ?? undefined, coverOrientation);
             return (
               <a href={`/gallery/${album.slug}`} class="group block aspect-square rounded-lg overflow-hidden bg-[var(--btn-regular-bg)] transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
                 <img src={coverUrl} alt={album.title} class="w-full h-full object-cover transition duration-300 group-hover:scale-105" loading="lazy" />

--- a/frontend/src/lib/image-utils.ts
+++ b/frontend/src/lib/image-utils.ts
@@ -26,11 +26,14 @@ function extractUploadPath(src: string): string | null {
  * @param src - Ruta relativa (/uploads/images/xxx.jpg) o URL completa
  * @param width - Ancho máximo en píxeles (opcional). Para vista completa usa 4096 o superior
  * @param quality - Calidad 1-100 (default: 80, para fotos de alta calidad usa 95)
+ * @param version - Cache buster opcional (ej. orientación). Cualquier valor que cambie cuando
+ *   la imagen cambia (ej. al rotarla en admin) → URL distinta → cache invalidado automáticamente.
  */
 export function getOptimizedImageUrl(
   src: string,
   width?: number,
-  quality = 80
+  quality = 80,
+  version?: string | number,
 ): string {
   const path = extractUploadPath(src);
   if (!path) return src;
@@ -40,6 +43,9 @@ export function getOptimizedImageUrl(
   params.set('path', path);
   if (width && width > 0) params.set('w', String(width));
   params.set('q', String(Math.min(100, Math.max(1, quality))));
+  if (version !== undefined && version !== null && version !== '') {
+    params.set('v', String(version));
+  }
 
   return `${base}/media/serve?${params.toString()}`;
 }
@@ -49,11 +55,13 @@ export function getOptimizedImageUrl(
  * Usa el endpoint serve para aplicar orientación EXIF y rotación del usuario.
  * Nota: archivos grandes (ej. 66MB) tardarán más en cargar.
  */
-export function getOriginalImageUrl(src: string): string {
+export function getOriginalImageUrl(
+  src: string,
+  version?: string | number,
+): string {
   const uploadPath = extractUploadPath(src);
   if (!uploadPath) return src;
-  // Usar serve para aplicar orientación EXIF y rotación guardada (misma lógica que optimizada)
-  return getOptimizedImageUrl(src, undefined, 95);
+  return getOptimizedImageUrl(src, undefined, 95, version);
 }
 
 /**
@@ -62,16 +70,23 @@ export function getOriginalImageUrl(src: string): string {
 export function getOptimizedImageSrcSet(
   src: string,
   widths: number[] = [400, 800, 1200],
-  quality = 80
+  quality = 80,
+  version?: string | number,
 ): string {
   const path = extractUploadPath(src);
   if (!path) return '';
 
   const base = getBackendApiUrl().replace(/\/$/, '');
   return widths
-    .map(
-      (w) =>
-        `${base}/media/serve?path=${encodeURIComponent(path)}&w=${w}&q=${quality} ${w}w`
-    )
+    .map((w) => {
+      const params = new URLSearchParams();
+      params.set('path', path);
+      params.set('w', String(w));
+      params.set('q', String(quality));
+      if (version !== undefined && version !== null && version !== '') {
+        params.set('v', String(version));
+      }
+      return `${base}/media/serve?${params.toString()} ${w}w`;
+    })
     .join(', ');
 }

--- a/frontend/src/pages/gallery/[slug].astro
+++ b/frontend/src/pages/gallery/[slug].astro
@@ -40,6 +40,7 @@ const processedImages = images.map((img: any) => {
     description: image.description,
     width: image.width,
     height: image.height,
+    orientation: image.orientation ?? 0,
   };
 }).filter(Boolean);
 ---


### PR DESCRIPTION
## Diagnóstico

El endpoint \`/api/media/serve\` devolvía:
\`\`\`
Cache-Control: public, max-age=31536000, immutable
\`\`\`

\`immutable\` le dice al browser/proxies: *"esta imagen jamás cambia, no me revalides en 1 año"*. Pero **rotar SÍ cambia la imagen**. Por eso:

- Galería pública: tras rotar una foto en admin, los visitantes seguían viendo la vieja por hasta 1 año.
- Admin: el cache buster \`&_o=270\` ayudaba sólo parcialmente y sólo en el modal de detalle.

Sumado a eso, el flujo de \`handleRotate\` en MediaLibrary se quedaba en silencio cuando algo fallaba (sin feedback al usuario).

## Cambios

### Backend (\`media.controller.ts\`)
- **Cache-Control** ahora: \`public, max-age=2592000, stale-while-revalidate=86400\`. **Sin** \`immutable\`.
- **ETag dinámico** basado en \`path + orientation + width + height + quality + format\`. Si rotás → ETag cambia → cache invalidado.
- Soporta \`If-None-Match\` → \`304 Not Modified\` cuando nada cambió.
- Acepta query \`v\` (cache buster) — junto con el ETag, da invalidación inmediata.

### Frontend (\`image-utils.ts\`)
- \`getOptimizedImageUrl(src, w, q, version?)\`, \`getOriginalImageUrl(src, version?)\` y \`getOptimizedImageSrcSet(src, widths, q, version?)\` aceptan \`version\`.
- Si la version cambia (ej: nueva orientación), la URL cambia → cache miss garantizado en browser y proxies.

### Componentes (galería pública)
- \`AlbumGrid\`, \`AlbumCarousel\`, \`InstagramModal\`, \`AlbumCard\`, \`GalleryPreview\`: pasan \`image.orientation ?? 0\` como version.
- \`gallery/[slug].astro\` propaga \`orientation\` desde el backend al componente.
- Resultado: rotaciones desde el admin se ven al instante en la galería pública.

### MediaLibrary admin (\`handleRotate\`)
- Toast \`info\` "Rotando ±N°…" inmediato — feedback visual aunque la red tarde.
- \`console.log('[handleRotate] start', ...)\` y \`console.log('[handleRotate] success', ...)\` con info clara para debug en DevTools.
- Validación de \`selectedMedia._id\` antes del PATCH.
- \`setSelectedMedia(updated)\` con la response del PATCH (no spread optimista) — si el backend rechaza, el state no miente.
- Toast de error con el detalle real (\`error.message || error.data.message\`).
- Cache buster \`&_o=...\` reemplazado por la nueva firma \`version\` de \`image-utils\`.

## Test plan
- [x] Build backend (\`npm run build\`) limpio
- [x] Build frontend (\`pnpm build\`) limpio
- [ ] Tras deploy: en \`/admin/media\`, rotar una foto → toast inmediato, foto se actualiza al instante.
- [ ] Tras rotar: ir a \`/gallery/<slug>\` → la foto se ve rotada (sin esperar 1 año).
- [ ] DevTools Network → confirmar que el response de \`/api/media/serve\` ya NO tiene \`immutable\` y trae \`ETag\`.
- [ ] Refresh de la página → segunda request a misma URL devuelve 304.

## Side benefits
- **Performance**: el ETag permite revalidación barata (304 = sólo headers, no se baja la imagen). Combinado con el cache largo, mejora notoriamente la sensación de la galería en visitas repetidas.
- **Logs**: cualquier futuro problema de rotación se diagnostica abriendo Console (handler imprime estado de entrada y salida).