### PR TITLE
feat(media): cache on-disk de variantes Sharp

### DIFF
--- a/backend/src/media/media.controller.ts
+++ b/backend/src/media/media.controller.ts
@@ -37,16 +37,21 @@ import { MediaService } from './media.service';
 import { CreateMediaDto } from './dto/create-media.dto';
 import { UpdateMediaDto } from './dto/update-media.dto';
 import { MediaDocument } from './schemas/media.schema';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as sharp from 'sharp';
+
+const CACHE_DIR = path.resolve(process.cwd(), 'uploads/.cache');
 
 @ApiTags('media')
 @Controller('media')
 export class MediaController {
   private readonly logger = new Logger(MediaController.name);
 
-  constructor(private readonly mediaService: MediaService) {}
+  constructor(private readonly mediaService: MediaService) {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+  }
 
   @Post('upload')
   @UseGuards(JwtAuthGuard, RolesGuard)
@@ -236,6 +241,19 @@ export class MediaController {
       return new StreamableFile(buffer, { type: 'image/svg+xml' });
     }
 
+    const mimeType = outputFormat === 'webp' ? 'image/webp' : 'image/jpeg';
+    const cacheKey = crypto
+      .createHash('sha256')
+      .update(`${cleanPath}-${userOrientation}-${width ?? 0}-${height ?? 0}-${quality}-${outputFormat}`)
+      .digest('hex');
+    const cachePath = path.join(CACHE_DIR, `${cacheKey}.${outputFormat}`);
+
+    if (fs.existsSync(cachePath)) {
+      const buffer = fs.readFileSync(cachePath);
+      res.setHeader('Content-Type', mimeType);
+      return new StreamableFile(buffer, { type: mimeType });
+    }
+
     try {
       let pipeline = sharp(fullPath)
         .rotate(); // Sin argumentos aplica EXIF orientation (equivale a autoOrient)
@@ -252,7 +270,14 @@ export class MediaController {
       const buffer = outputFormat === 'webp'
         ? await pipeline.webp({ quality }).toBuffer()
         : await pipeline.jpeg({ quality }).toBuffer();
-      const mimeType = outputFormat === 'webp' ? 'image/webp' : 'image/jpeg';
+
+      try {
+        fs.writeFileSync(cachePath + '.tmp', buffer);
+        fs.renameSync(cachePath + '.tmp', cachePath);
+      } catch {
+        // Cache write failure is non-fatal
+      }
+
       res.setHeader('Content-Type', mimeType);
       return new StreamableFile(buffer, { type: mimeType });
     } catch (err) {
@@ -260,6 +285,22 @@ export class MediaController {
       const buffer = fs.readFileSync(fullPath);
       return new StreamableFile(buffer);
     }
+  }
+
+  @Delete('cache')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Limpiar cache de variantes procesadas (solo admin)' })
+  @ApiResponse({ status: 200, description: 'Cache eliminado' })
+  clearCache(): { deleted: number } {
+    if (!fs.existsSync(CACHE_DIR)) return { deleted: 0 };
+    const files = fs.readdirSync(CACHE_DIR);
+    for (const f of files) {
+      fs.rmSync(path.join(CACHE_DIR, f), { force: true });
+    }
+    return { deleted: files.length };
   }
 
   @Get(':id')


### PR DESCRIPTION
## Summary
- El endpoint `/media/serve` ahora persiste cada variante procesada en `uploads/.cache/<sha256>.{webp,jpeg}`
- Requests repetidos para la misma combinación (path + orientación + w/h/quality/format) sirven directo del disco sin ejecutar Sharp
- Cache key = mismos parámetros que el ETag existente → invalidación implícita al rotar imágenes
- Escritura atómica (.tmp → rename) para evitar archivos parciales en concurrencia
- Fallo de escritura es non-fatal: sigue sirviendo desde el buffer de Sharp
- Nuevo endpoint `DELETE /media/cache` (solo admin) para vaciar el cache manualmente

## Test plan
- [ ] Verificar primer request procesa con Sharp y crea archivo en `uploads/.cache/`
- [ ] Verificar segundo request con mismos params sirve del cache (más rápido)
- [ ] Verificar que rotar una imagen en admin invalida el cache (nueva orientación → nueva cache key)
- [ ] Verificar que `DELETE /media/cache` limpia los archivos y retorna `{ deleted: N }`
- [ ] Verificar que SVGs no van al cache (pasan por la rama SVG antes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)