### PR TITLE
feat(security): rate-limiting y CORS acotado a bfmu.dev

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/passport": "^10.0.3",
         "@nestjs/platform-express": "^10.4.0",
         "@nestjs/swagger": "^7.4.2",
+        "@nestjs/throttler": "^6.5.0",
         "archiver": "^7.0.1",
         "axios": "^1.7.9",
         "bcryptjs": "^2.4.3",
@@ -2401,6 +2402,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nuxtjs/opencollective": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.4.0",
     "@nestjs/swagger": "^7.4.2",
+    "@nestjs/throttler": "^6.5.0",
     "archiver": "^7.0.1",
     "axios": "^1.7.9",
     "bcryptjs": "^2.4.3",

--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Post, Get, Body, Req, UseGuards } from '@nestjs/common';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { Request } from 'express';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiBody } from '@nestjs/swagger';
 import { AnalyticsService } from './analytics.service';
@@ -12,9 +13,12 @@ export class AnalyticsController {
   constructor(private readonly analyticsService: AnalyticsService) {}
 
   @Post('track')
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 30, ttl: 60000 } })
   @ApiOperation({ summary: 'Registrar una vista de página (público)' })
   @ApiBody({ type: TrackPageViewDto })
   @ApiResponse({ status: 201, description: 'Vista registrada' })
+  @ApiResponse({ status: 429, description: 'Demasiadas requests' })
   async track(@Body() dto: TrackPageViewDto, @Req() req: Request) {
     const ip = this.getClientIp(req);
     const userAgent = req.get('User-Agent');

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { MongooseModule } from '@nestjs/mongoose';
 import { SpotifyModule } from './spotify/spotify.module';
 import { ConfigModule } from '@nestjs/config';
@@ -17,6 +18,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
     ConfigModule.forRoot({
       isGlobal: true,
     }),
+    ThrottlerModule.forRoot([{ name: 'default', ttl: 60000, limit: 100 }]),
     MongooseModule.forRoot(
       process.env.MONGODB_URI || 'mongodb://localhost:27017/blog',
     ),

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -14,6 +14,7 @@ import {
   UploadedFile,
   BadRequestException,
 } from '@nestjs/common';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthGuard } from '@nestjs/passport';
 import { Response, Request } from 'express';
@@ -49,9 +50,12 @@ export class AuthController {
   }
 
   @Post('login')
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Iniciar sesión' })
   @ApiResponse({ status: 200, description: 'Login exitoso' })
+  @ApiResponse({ status: 429, description: 'Demasiados intentos, esperá 1 minuto' })
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -46,8 +46,21 @@ async function bootstrap() {
     }),
   );
 
+  const allowedOrigins = [
+    'https://bfmu.dev',
+    'https://www.bfmu.dev',
+    'http://localhost:4321',
+    'http://localhost:3000',
+  ];
   app.enableCors({
-    origin: '*',
+    origin: (origin, callback) => {
+      // Permitir requests sin Origin (SSR server-side, curl, etc.)
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error(`CORS: origin not allowed — ${origin}`));
+      }
+    },
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     allowedHeaders: 'Content-Type, Accept, Authorization',
   });

--- a/backend/src/media/media.controller.ts
+++ b/backend/src/media/media.controller.ts
@@ -41,6 +41,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as sharp from 'sharp';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 
 const CACHE_DIR = path.resolve(process.cwd(), 'uploads/.cache');
 
@@ -54,13 +55,15 @@ export class MediaController {
   }
 
   @Post('upload')
-  @UseGuards(JwtAuthGuard, RolesGuard)
+  @UseGuards(ThrottlerGuard, JwtAuthGuard, RolesGuard)
+  @Throttle({ default: { limit: 20, ttl: 60000 } })
   @Roles('admin', 'editor')
   @UseInterceptors(FileInterceptor('file'))
   @ApiBearerAuth()
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: 'Subir archivo y crear registro de media (requiere autenticación)' })
   @ApiResponse({ status: 201, description: 'Media creado correctamente' })
+  @ApiResponse({ status: 429, description: 'Demasiados uploads, esperá 1 minuto' })
   async upload(@UploadedFile() file: any, @Body() body?: any) {
     if (!file) {
       this.logger.warn('Upload attempt without file');


### PR DESCRIPTION
## Summary
- **CORS**: `origin: '*'` → whitelist `[bfmu.dev, www.bfmu.dev, localhost:4321, localhost:3000]`. Requests sin `Origin` header (SSR server-side, curl) siguen pasando.
- **Rate-limiting** via `@nestjs/throttler` v6:
  - `POST /auth/login`: 5 req/min por IP — protección brute-force
  - `POST /analytics/track`: 30 req/min por IP — protección spam
  - `POST /media/upload`: 20 req/min por IP — protección adicional (ya requiere JWT)
- `ThrottlerModule.forRoot` registrado en AppModule con default permisivo (100 req/min); los 3 endpoints arriba lo sobreescriben con `@Throttle()`.

## Test plan
- [ ] Verificar que el frontend en `bfmu.dev` sigue funcionando (CORS OK)
- [ ] Verificar que desde otro origen se recibe error CORS
- [ ] Verificar que 6 intentos de login seguidos devuelven 429 en el 6to
- [ ] Verificar que el deploy levanta correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)