### PR TITLE
feat(books): sección de libros leídos

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { HealthModule } from './health/health.module';
 import { HomepageModule } from './homepage/homepage.module';
 import { NavbarModule } from './navbar/navbar.module';
 import { AnalyticsModule } from './analytics/analytics.module';
+import { BooksModule } from './books/books.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
     HomepageModule,
     NavbarModule,
     AnalyticsModule,
+    BooksModule,
   ],
   controllers: [],
   providers: [],

--- a/backend/src/backup/backup.module.ts
+++ b/backend/src/backup/backup.module.ts
@@ -18,6 +18,7 @@ import {
   HomepageConfig,
   HomepageConfigSchema,
 } from '../homepage/schemas/homepage-config.schema';
+import { Book, BookSchema } from '../books/schemas/book.schema';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import {
       { name: ApiIntegration.name, schema: ApiIntegrationSchema },
       { name: OAuthProvider.name, schema: OAuthProviderSchema },
       { name: HomepageConfig.name, schema: HomepageConfigSchema },
+      { name: Book.name, schema: BookSchema },
     ]),
   ],
   controllers: [BackupController],

--- a/backend/src/backup/backup.service.ts
+++ b/backend/src/backup/backup.service.ts
@@ -29,6 +29,7 @@ import {
   HomepageConfig,
   HomepageConfigDocument,
 } from '../homepage/schemas/homepage-config.schema';
+import { Book, BookDocument } from '../books/schemas/book.schema';
 
 const BACKUP_VERSION = '1.1';
 const COLLECTIONS = [
@@ -39,7 +40,7 @@ const COLLECTIONS = [
   'apiintegrations',
   'oauthproviders',
 ] as const;
-const EXTRA_COLLECTIONS = ['homepage_config'] as const;
+const EXTRA_COLLECTIONS = ['homepage_config', 'books'] as const;
 const RATE_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_BACKUP_SIZE = Number(process.env.BACKUP_MAX_SIZE) || 2 * 1024 * 1024 * 1024; // 2GB
 
@@ -72,6 +73,8 @@ export class BackupService {
     private oauthProviderModel: Model<OAuthProviderDocument>,
     @InjectModel(HomepageConfig.name)
     private homepageConfigModel: Model<HomepageConfigDocument>,
+    @InjectModel(Book.name)
+    private bookModel: Model<BookDocument>,
   ) {}
 
   private getUploadsPath(): string {
@@ -87,6 +90,7 @@ export class BackupService {
       apiintegrations: this.apiIntegrationModel,
       oauthproviders: this.oauthProviderModel,
       homepage_config: this.homepageConfigModel,
+      books: this.bookModel,
     };
   }
 
@@ -136,6 +140,9 @@ export class BackupService {
           break;
         case 'users':
           if (d.avatar) d.avatar = toRelativePath(d.avatar);
+          break;
+        case 'books':
+          if (d.cover) d.cover = toRelativePath(d.cover);
           break;
         case 'homepage_config':
           if (Array.isArray(d.sections)) {

--- a/backend/src/books/books.controller.ts
+++ b/backend/src/books/books.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { BooksService } from './books.service';
+import { CreateBookDto } from './dto/create-book.dto';
+import { UpdateBookDto } from './dto/update-book.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+
+@ApiTags('books')
+@Controller('books')
+export class BooksController {
+  constructor(private readonly booksService: BooksService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Listar todos los libros (público)' })
+  @ApiResponse({ status: 200, description: 'Lista de libros' })
+  findAll() {
+    return this.booksService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Obtener un libro por ID (público)' })
+  @ApiParam({ name: 'id', description: 'ID del libro' })
+  @ApiResponse({ status: 200, description: 'Libro encontrado' })
+  findOne(@Param('id') id: string) {
+    return this.booksService.findOne(id);
+  }
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Crear libro (solo admin)' })
+  @ApiResponse({ status: 201, description: 'Libro creado' })
+  create(@Body() dto: CreateBookDto) {
+    return this.booksService.create(dto);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Actualizar libro (solo admin)' })
+  @ApiParam({ name: 'id', description: 'ID del libro' })
+  @ApiResponse({ status: 200, description: 'Libro actualizado' })
+  update(@Param('id') id: string, @Body() dto: UpdateBookDto) {
+    return this.booksService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('admin')
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Eliminar libro (solo admin)' })
+  @ApiParam({ name: 'id', description: 'ID del libro' })
+  @ApiResponse({ status: 204, description: 'Libro eliminado' })
+  remove(@Param('id') id: string) {
+    return this.booksService.remove(id);
+  }
+}

--- a/backend/src/books/books.module.ts
+++ b/backend/src/books/books.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Book, BookSchema } from './schemas/book.schema';
+import { BooksService } from './books.service';
+import { BooksController } from './books.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Book.name, schema: BookSchema }]),
+  ],
+  controllers: [BooksController],
+  providers: [BooksService],
+})
+export class BooksModule {}

--- a/backend/src/books/books.service.ts
+++ b/backend/src/books/books.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Book, BookDocument } from './schemas/book.schema';
+import { CreateBookDto } from './dto/create-book.dto';
+import { UpdateBookDto } from './dto/update-book.dto';
+
+@Injectable()
+export class BooksService {
+  constructor(
+    @InjectModel(Book.name) private readonly bookModel: Model<BookDocument>,
+  ) {}
+
+  async findAll(): Promise<BookDocument[]> {
+    return this.bookModel.find().sort({ readAt: -1, createdAt: -1 }).lean().exec();
+  }
+
+  async findOne(id: string): Promise<BookDocument> {
+    const book = await this.bookModel.findById(id).lean().exec();
+    if (!book) throw new NotFoundException('Libro no encontrado');
+    return book;
+  }
+
+  async create(dto: CreateBookDto): Promise<BookDocument> {
+    const book = new this.bookModel({
+      ...dto,
+      readAt: dto.readAt ? new Date(dto.readAt) : undefined,
+    });
+    return book.save();
+  }
+
+  async update(id: string, dto: UpdateBookDto): Promise<BookDocument> {
+    const update: Record<string, unknown> = { ...dto };
+    if (dto.readAt) update.readAt = new Date(dto.readAt);
+    const book = await this.bookModel
+      .findByIdAndUpdate(id, { $set: update }, { new: true })
+      .lean()
+      .exec();
+    if (!book) throw new NotFoundException('Libro no encontrado');
+    return book;
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.bookModel.findByIdAndDelete(id).exec();
+    if (!result) throw new NotFoundException('Libro no encontrado');
+  }
+}

--- a/backend/src/books/dto/create-book.dto.ts
+++ b/backend/src/books/dto/create-book.dto.ts
@@ -1,0 +1,36 @@
+import { IsString, IsNotEmpty, IsOptional, IsDateString, IsInt, Min, Max } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateBookDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  author: string;
+
+  @ApiPropertyOptional({ description: 'URL de la portada (media library o externa)' })
+  @IsOptional()
+  @IsString()
+  cover?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  readAt?: string;
+
+  @ApiPropertyOptional({ minimum: 1, maximum: 5 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating?: number;
+
+  @ApiPropertyOptional({ description: 'Slug del post asociado (opinión)' })
+  @IsOptional()
+  @IsString()
+  postSlug?: string;
+}

--- a/backend/src/books/dto/update-book.dto.ts
+++ b/backend/src/books/dto/update-book.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateBookDto } from './create-book.dto';
+
+export class UpdateBookDto extends PartialType(CreateBookDto) {}

--- a/backend/src/books/schemas/book.schema.ts
+++ b/backend/src/books/schemas/book.schema.ts
@@ -1,0 +1,29 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type BookDocument = Book & Document;
+
+@Schema({ timestamps: true, collection: 'books' })
+export class Book {
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ required: true })
+  author: string;
+
+  @Prop()
+  cover: string;
+
+  @Prop()
+  readAt: Date;
+
+  @Prop({ min: 1, max: 5 })
+  rating: number;
+
+  @Prop()
+  postSlug: string;
+}
+
+export const BookSchema = SchemaFactory.createForClass(Book);
+
+BookSchema.index({ readAt: -1 });

--- a/frontend/src/components/admin/AdminLayout.astro
+++ b/frontend/src/components/admin/AdminLayout.astro
@@ -168,6 +168,32 @@ if (typeof window !== 'undefined') {
           </a>
 
           <a
+            href="/admin/books"
+            data-admin-only="true"
+            class:list={[
+              "hidden admin-link admin-nav-link flex items-center gap-3 rounded-lg px-3 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700",
+              {
+                'bg-gray-100 dark:bg-gray-700': Astro.url.pathname.startsWith('/admin/books'),
+              },
+            ]}
+          >
+            <svg
+              class="h-5 w-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
+            </svg>
+            <span>Libros</span>
+          </a>
+
+          <a
             href="/admin/homepage"
             data-admin-only="true"
             class:list={[

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -848,3 +848,48 @@ export async function restoreBackup(file: File): Promise<RestoreResult> {
     clearTimeout(timeoutId);
   }
 }
+
+// ─── Books ────────────────────────────────────────────────────────────────────
+
+export interface Book {
+  _id: string;
+  title: string;
+  author: string;
+  cover?: string;
+  readAt?: string;
+  rating?: number;
+  postSlug?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateBookRequest {
+  title: string;
+  author: string;
+  cover?: string;
+  readAt?: string;
+  rating?: number;
+  postSlug?: string;
+}
+
+export type UpdateBookRequest = Partial<CreateBookRequest>;
+
+export async function adminGetBooks(): Promise<Book[]> {
+  return apiGet<Book[]>('books');
+}
+
+export async function adminGetBook(id: string): Promise<Book> {
+  return apiGet<Book>(`books/${id}`);
+}
+
+export async function adminCreateBook(data: CreateBookRequest): Promise<Book> {
+  return apiPost<Book>('books', data);
+}
+
+export async function adminUpdateBook(id: string, data: UpdateBookRequest): Promise<Book> {
+  return apiPatch<Book>(`books/${id}`, data);
+}
+
+export async function adminDeleteBook(id: string): Promise<void> {
+  return apiDelete<void>(`books/${id}`);
+}

--- a/frontend/src/lib/api-books.ts
+++ b/frontend/src/lib/api-books.ts
@@ -1,0 +1,37 @@
+import { getBackendApiUrl } from './env';
+
+export interface Book {
+  _id: string;
+  title: string;
+  author: string;
+  cover?: string;
+  readAt?: string;
+  rating?: number;
+  postSlug?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function getBooksUrl(): string {
+  return `${getBackendApiUrl().replace(/\/$/, '')}/books`;
+}
+
+export async function fetchBooks(): Promise<Book[]> {
+  try {
+    const res = await fetch(getBooksUrl());
+    if (!res.ok) return [];
+    return res.json();
+  } catch {
+    return [];
+  }
+}
+
+export async function fetchBook(id: string): Promise<Book | null> {
+  try {
+    const res = await fetch(`${getBooksUrl()}/${id}`);
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/pages/admin/books/[id]/edit.astro
+++ b/frontend/src/pages/admin/books/[id]/edit.astro
@@ -1,0 +1,121 @@
+---
+import AdminLayout from '@components/admin/AdminLayout.astro'
+import { adminGetBook } from '../../../../lib/admin-api'
+
+const { id } = Astro.params
+
+let book: Awaited<ReturnType<typeof adminGetBook>> | null = null
+try {
+  book = await adminGetBook(id!)
+} catch {
+  return Astro.redirect('/admin/books')
+}
+
+function toDateInput(dateStr: string | undefined): string {
+  if (!dateStr) return ''
+  return new Date(dateStr).toISOString().split('T')[0]
+}
+---
+
+<AdminLayout title={`Editar — ${book.title}`}>
+  <div class="max-w-lg space-y-6">
+    <div class="flex items-center gap-4">
+      <a href="/admin/books" data-no-swup class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+        ← Volver
+      </a>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Editar libro</h1>
+    </div>
+
+    <form id="book-form" data-book-id={book._id} class="space-y-5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Título *</label>
+        <input name="title" required type="text" value={book.title}
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Autor *</label>
+        <input name="author" required type="text" value={book.author}
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Portada (URL)</label>
+        <input name="cover" type="text" value={book.cover ?? ''}
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fecha de lectura</label>
+          <input name="readAt" type="date" value={toDateInput(book.readAt)}
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rating (1–5)</label>
+          <select name="rating"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <option value="" selected={!book.rating}>Sin rating</option>
+            <option value="1" selected={book.rating === 1}>★☆☆☆☆</option>
+            <option value="2" selected={book.rating === 2}>★★☆☆☆</option>
+            <option value="3" selected={book.rating === 3}>★★★☆☆</option>
+            <option value="4" selected={book.rating === 4}>★★★★☆</option>
+            <option value="5" selected={book.rating === 5}>★★★★★</option>
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slug del post (opinión)</label>
+        <input name="postSlug" type="text" value={book.postSlug ?? ''}
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+      </div>
+
+      <div id="form-error" class="hidden rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400"></div>
+
+      <div class="flex gap-3 pt-2">
+        <button type="submit"
+          class="flex-1 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors disabled:opacity-50">
+          Guardar cambios
+        </button>
+        <a href="/admin/books" data-no-swup
+          class="rounded-md border border-gray-300 dark:border-gray-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+          Cancelar
+        </a>
+      </div>
+    </form>
+  </div>
+</AdminLayout>
+
+<script>
+  import { adminUpdateBook } from '../../../../lib/admin-api'
+
+  const form = document.getElementById('book-form') as HTMLFormElement
+  const errorEl = document.getElementById('form-error')!
+  const bookId = form.dataset.bookId!
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.classList.add('hidden')
+
+    const data = Object.fromEntries(new FormData(form))
+    const submit = form.querySelector('[type=submit]') as HTMLButtonElement
+    submit.disabled = true
+
+    try {
+      await adminUpdateBook(bookId, {
+        title: String(data.title),
+        author: String(data.author),
+        cover: data.cover ? String(data.cover) : undefined,
+        readAt: data.readAt ? String(data.readAt) : undefined,
+        rating: data.rating ? Number(data.rating) : undefined,
+        postSlug: data.postSlug ? String(data.postSlug) : undefined,
+      })
+      window.location.href = '/admin/books'
+    } catch (err: any) {
+      errorEl.textContent = err.message || 'Error al guardar'
+      errorEl.classList.remove('hidden')
+      submit.disabled = false
+    }
+  })
+</script>

--- a/frontend/src/pages/admin/books/index.astro
+++ b/frontend/src/pages/admin/books/index.astro
@@ -1,0 +1,133 @@
+---
+import AdminLayout from '@components/admin/AdminLayout.astro'
+import { adminGetBooks } from '../../../lib/admin-api'
+import { getOptimizedImageUrl } from '../../../lib/image-utils'
+
+let books: Awaited<ReturnType<typeof adminGetBooks>> = []
+try {
+  books = await adminGetBooks()
+} catch {
+  // Will show empty state; auth handled client-side
+}
+
+function coverUrl(cover: string | undefined): string {
+  if (!cover) return ''
+  if (cover.startsWith('/uploads/')) return getOptimizedImageUrl(cover, 80)
+  return cover
+}
+
+function stars(rating: number | undefined): string {
+  if (!rating) return '—'
+  return '★'.repeat(rating) + '☆'.repeat(5 - rating)
+}
+---
+
+<AdminLayout title="Libros">
+  <div class="space-y-6">
+    <div class="flex items-center justify-between">
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Libros</h1>
+      <a
+        href="/admin/books/new"
+        data-no-swup
+        class="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-700"
+      >
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        Nuevo libro
+      </a>
+    </div>
+
+    {books.length === 0 ? (
+      <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-12 text-center">
+        <p class="text-gray-500 dark:text-gray-400">No hay libros cargados aún.</p>
+        <a href="/admin/books/new" data-no-swup class="mt-4 inline-block text-indigo-600 dark:text-indigo-400 hover:underline text-sm">
+          Agregar el primero →
+        </a>
+      </div>
+    ) : (
+      <div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+        <table class="w-full text-sm">
+          <thead class="bg-gray-50 dark:bg-gray-700 text-gray-600 dark:text-gray-300 text-xs uppercase">
+            <tr>
+              <th class="px-4 py-3 text-left w-12"></th>
+              <th class="px-4 py-3 text-left">Título / Autor</th>
+              <th class="px-4 py-3 text-left hidden sm:table-cell">Rating</th>
+              <th class="px-4 py-3 text-left hidden md:table-cell">Leído</th>
+              <th class="px-4 py-3 text-left hidden md:table-cell">Post</th>
+              <th class="px-4 py-3 text-right">Acciones</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 dark:divide-gray-700 bg-white dark:bg-gray-800">
+            {books.map((book) => (
+              <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                <td class="px-4 py-3">
+                  {coverUrl(book.cover) ? (
+                    <img src={coverUrl(book.cover)} alt="" class="h-12 w-8 object-cover rounded shadow-sm" />
+                  ) : (
+                    <div class="h-12 w-8 rounded bg-gray-100 dark:bg-gray-700 flex items-center justify-center text-lg">📖</div>
+                  )}
+                </td>
+                <td class="px-4 py-3">
+                  <p class="font-medium text-gray-900 dark:text-white leading-snug">{book.title}</p>
+                  <p class="text-gray-500 dark:text-gray-400 text-xs">{book.author}</p>
+                </td>
+                <td class="px-4 py-3 hidden sm:table-cell text-yellow-500 dark:text-yellow-400 text-xs">
+                  {stars(book.rating)}
+                </td>
+                <td class="px-4 py-3 hidden md:table-cell text-gray-500 dark:text-gray-400">
+                  {book.readAt ? new Date(book.readAt).toLocaleDateString('es-AR', { year: 'numeric', month: 'short' }) : '—'}
+                </td>
+                <td class="px-4 py-3 hidden md:table-cell">
+                  {book.postSlug ? (
+                    <a href={`/posts/${book.postSlug}`} target="_blank" class="text-indigo-600 dark:text-indigo-400 hover:underline text-xs">
+                      {book.postSlug}
+                    </a>
+                  ) : (
+                    <span class="text-gray-400 text-xs">—</span>
+                  )}
+                </td>
+                <td class="px-4 py-3 text-right">
+                  <div class="flex items-center justify-end gap-2">
+                    <a
+                      href={`/admin/books/${book._id}/edit`}
+                      data-no-swup
+                      class="rounded px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                    >
+                      Editar
+                    </a>
+                    <button
+                      data-delete-book={book._id}
+                      data-book-title={book.title}
+                      class="rounded px-2 py-1 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                    >
+                      Eliminar
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )}
+  </div>
+</AdminLayout>
+
+<script>
+  import { adminDeleteBook } from '../../../lib/admin-api'
+
+  document.querySelectorAll('[data-delete-book]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const id = (btn as HTMLElement).dataset.deleteBook!
+      const title = (btn as HTMLElement).dataset.bookTitle!
+      if (!confirm(`¿Eliminar "${title}"?`)) return
+      try {
+        await adminDeleteBook(id)
+        window.location.reload()
+      } catch (e: any) {
+        alert(`Error al eliminar: ${e.message}`)
+      }
+    })
+  })
+</script>

--- a/frontend/src/pages/admin/books/new.astro
+++ b/frontend/src/pages/admin/books/new.astro
@@ -1,0 +1,107 @@
+---
+import AdminLayout from '@components/admin/AdminLayout.astro'
+---
+
+<AdminLayout title="Nuevo libro">
+  <div class="max-w-lg space-y-6">
+    <div class="flex items-center gap-4">
+      <a href="/admin/books" data-no-swup class="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+        ← Volver
+      </a>
+      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Nuevo libro</h1>
+    </div>
+
+    <form id="book-form" class="space-y-5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Título *</label>
+        <input name="title" required type="text" placeholder="El nombre del viento"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Autor *</label>
+        <input name="author" required type="text" placeholder="Patrick Rothfuss"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Portada (URL)</label>
+        <input name="cover" type="text" placeholder="/uploads/images/portada.jpg o https://..."
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Podés pegar una URL de la biblioteca de media o una URL externa.</p>
+      </div>
+
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fecha de lectura</label>
+          <input name="readAt" type="date"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rating (1–5)</label>
+          <select name="rating"
+            class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500">
+            <option value="">Sin rating</option>
+            <option value="1">★☆☆☆☆</option>
+            <option value="2">★★☆☆☆</option>
+            <option value="3">★★★☆☆</option>
+            <option value="4">★★★★☆</option>
+            <option value="5">★★★★★</option>
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Slug del post (opinión)</label>
+        <input name="postSlug" type="text" placeholder="mi-opinion-sobre-este-libro"
+          class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Si tenés un post con tu opinión, pegá el slug acá.</p>
+      </div>
+
+      <div id="form-error" class="hidden rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-4 py-3 text-sm text-red-700 dark:text-red-400"></div>
+
+      <div class="flex gap-3 pt-2">
+        <button type="submit"
+          class="flex-1 rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors disabled:opacity-50">
+          Guardar libro
+        </button>
+        <a href="/admin/books" data-no-swup
+          class="rounded-md border border-gray-300 dark:border-gray-600 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+          Cancelar
+        </a>
+      </div>
+    </form>
+  </div>
+</AdminLayout>
+
+<script>
+  import { adminCreateBook } from '../../../lib/admin-api'
+
+  const form = document.getElementById('book-form') as HTMLFormElement
+  const errorEl = document.getElementById('form-error')!
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault()
+    errorEl.classList.add('hidden')
+
+    const data = Object.fromEntries(new FormData(form))
+    const submit = form.querySelector('[type=submit]') as HTMLButtonElement
+    submit.disabled = true
+
+    try {
+      await adminCreateBook({
+        title: String(data.title),
+        author: String(data.author),
+        cover: data.cover ? String(data.cover) : undefined,
+        readAt: data.readAt ? String(data.readAt) : undefined,
+        rating: data.rating ? Number(data.rating) : undefined,
+        postSlug: data.postSlug ? String(data.postSlug) : undefined,
+      })
+      window.location.href = '/admin/books'
+    } catch (err: any) {
+      errorEl.textContent = err.message || 'Error al guardar'
+      errorEl.classList.remove('hidden')
+      submit.disabled = false
+    }
+  })
+</script>

--- a/frontend/src/pages/books/index.astro
+++ b/frontend/src/pages/books/index.astro
@@ -1,0 +1,86 @@
+---
+import MainGridLayout from '@layouts/MainGridLayout.astro'
+import { fetchBooks } from '../../lib/api-books'
+import { getOptimizedImageUrl } from '../../lib/image-utils'
+
+const books = await fetchBooks()
+
+function coverUrl(cover: string | undefined): string {
+  if (!cover) return ''
+  if (cover.startsWith('/uploads/')) return getOptimizedImageUrl(cover, 240)
+  return cover
+}
+
+function stars(rating: number | undefined): string {
+  if (!rating) return ''
+  return '★'.repeat(rating) + '☆'.repeat(5 - rating)
+}
+
+function formatDate(dateStr: string | undefined): string {
+  if (!dateStr) return ''
+  return new Date(dateStr).toLocaleDateString('es-AR', { year: 'numeric', month: 'long' })
+}
+---
+
+<MainGridLayout title="Libros" showProfile={false} showCategories={false} showTags={false} hideSidebar={true}>
+  <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative">
+    <div class="card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full">
+
+      <h1 class="text-3xl font-bold text-black/90 dark:text-white/90 mb-2">Libros</h1>
+      <p class="text-black/60 dark:text-white/60 mb-8">Lo que he leído y lo que pienso al respecto.</p>
+
+      {books.length === 0 && (
+        <p class="text-black/40 dark:text-white/40 text-center py-16">Aún no hay libros cargados.</p>
+      )}
+
+      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+        {books.map((book) => (
+          <div class="group flex flex-col gap-2">
+            <!-- Cover -->
+            <div class="relative aspect-[2/3] overflow-hidden rounded-lg bg-black/5 dark:bg-white/5 shadow-md transition-shadow group-hover:shadow-xl">
+              {coverUrl(book.cover) ? (
+                <img
+                  src={coverUrl(book.cover)}
+                  alt={`Portada de ${book.title}`}
+                  class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  loading="lazy"
+                />
+              ) : (
+                <div class="w-full h-full flex items-center justify-center text-4xl text-black/20 dark:text-white/20">
+                  📖
+                </div>
+              )}
+              {book.postSlug && (
+                <a
+                  href={`/posts/${book.postSlug}`}
+                  class="absolute inset-0 flex items-end justify-center pb-3 opacity-0 group-hover:opacity-100 transition-opacity bg-gradient-to-t from-black/70 to-transparent"
+                >
+                  <span class="text-white text-xs font-medium bg-black/40 px-3 py-1 rounded-full">
+                    Ver opinión →
+                  </span>
+                </a>
+              )}
+            </div>
+
+            <!-- Info -->
+            <div class="flex flex-col gap-0.5">
+              {book.rating && (
+                <span class="text-yellow-500 dark:text-yellow-400 text-xs tracking-tight">
+                  {stars(book.rating)}
+                </span>
+              )}
+              <h2 class="text-sm font-semibold text-black/90 dark:text-white/90 leading-snug line-clamp-2">
+                {book.title}
+              </h2>
+              <p class="text-xs text-black/50 dark:text-white/50">{book.author}</p>
+              {book.readAt && (
+                <p class="text-xs text-black/40 dark:text-white/40">{formatDate(book.readAt)}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+    </div>
+  </div>
+</MainGridLayout>


### PR DESCRIPTION
## Summary
Nueva sección `/books` para mostrar libros leídos con opiniones opcionales via post asociado.

**Backend**
- `BooksModule` nuevo: schema `Book` (title, author, cover, readAt, rating, postSlug)
- `GET /books` y `GET /books/:id` — público
- `POST /PATCH /DELETE /books` — solo admin
- `postSlug`: slug del post de opinión (string, no FK) — fácil de linkear en frontend

**Frontend**
- `/books` — página pública: grid de portadas con hover → "Ver opinión →"
- `/admin/books` — listado con tabla, delete
- `/admin/books/new` y `/admin/books/:id/edit` — formularios CRUD completos
- Sidebar admin: ítem "Libros" con ícono de libro

## Cómo usar
1. Ir a `/admin/books` → Nuevo libro
2. Llenar título, autor, portada (URL de media library o externa), fecha, rating, y opcionalmente el slug de un post existente con la opinión
3. El libro aparece en `/books`; si tiene postSlug, hovear la portada muestra "Ver opinión →"

## Test plan
- [ ] Crear un libro desde `/admin/books/new`
- [ ] Verificar que aparece en `/books`
- [ ] Editar el libro y verificar cambios
- [ ] Asociar un postSlug y verificar el link en la página pública
- [ ] Eliminar el libro y verificar que desaparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)