### PR TITLE
feat(homepage): rediseño completo — interactividad y vida

### DIFF
--- a/backend/src/homepage/homepage.service.ts
+++ b/backend/src/homepage/homepage.service.ts
@@ -78,10 +78,16 @@ const DEFAULT_SECTIONS = [
     config: {
       title: 'Últimos artículos',
       subtitle: 'Explora las publicaciones más recientes de mi blog.',
-      limit: 3,
+      limit: 4,
       ctaText: 'Ver todos los artículos',
       ctaHref: '/blogs/',
     },
+  },
+  {
+    id: 'now-footer',
+    enabled: true,
+    order: 7,
+    config: {},
   },
 ];
 

--- a/backend/src/homepage/homepage.service.ts
+++ b/backend/src/homepage/homepage.service.ts
@@ -13,6 +13,7 @@ const DEFAULT_SECTIONS = [
       imageUrls: [] as string[],
       carouselIntervalSeconds: 5.5,
       heightVh: 70,
+      eyebrow: 'BRYAN F. MUÑOZ M. · BOGOTÁ',
       title: 'Desarrollo, Fotografía y Reflexión',
       subtitle: 'Desarrollo soluciones. Capturo momentos. Reflexiono sobre historias. Aquí es donde todo converge.',
       ctaText: 'Explorar',
@@ -87,7 +88,10 @@ const DEFAULT_SECTIONS = [
     id: 'now-footer',
     enabled: true,
     order: 7,
-    config: {},
+    config: {
+      email: 'bfmumo@gmail.com',
+      thisWeek: [] as string[],
+    },
   },
 ];
 

--- a/frontend/src/components/admin/HomepageEditor.tsx
+++ b/frontend/src/components/admin/HomepageEditor.tsx
@@ -13,7 +13,9 @@ const SECTION_LABELS: Record<string, string> = {
   secciones: 'Grid de secciones',
   'gallery-preview': 'Preview galería',
   'ultimos-posts': 'Últimos artículos',
-  'now-listening': 'Ahora escuchando (Spotify)',
+  'now-listening': 'Actividad reciente (Spotify + libro + álbum)',
+  'actividad-reciente': 'Actividad reciente (Spotify + libro + álbum)',
+  'now-footer': 'Footer /now (reloj · esta semana · contacto)',
 };
 
 export function HomepageEditor() {
@@ -195,10 +197,16 @@ export function HomepageEditor() {
                     onUpdate={(c) => updateSectionConfig('ultimos-posts', c)}
                   />
                 )}
-                {section.id === 'now-listening' && (
+                {(section.id === 'now-listening' || section.id === 'actividad-reciente') && (
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    Muestra la canción actual de Spotify cuando hay algo reproduciéndose. No requiere configuración.
+                    Muestra la canción actual de Spotify, el último libro leído y el último álbum. No requiere configuración manual.
                   </p>
+                )}
+                {section.id === 'now-footer' && (
+                  <NowFooterFields
+                    config={section.config ?? {}}
+                    onUpdate={(c) => updateSectionConfig('now-footer', c)}
+                  />
                 )}
               </div>
             )}
@@ -350,6 +358,11 @@ function HeroFields({
           </button>
         </div>
       </div>
+      <Field
+        label="Eyebrow (texto sobre el título, dejar vacío para ocultar)"
+        value={(config.eyebrow as string) ?? ''}
+        onChange={(v) => onUpdate({ ...config, eyebrow: v })}
+      />
       <Field
         label="Título"
         value={(config.title as string) ?? ''}
@@ -555,6 +568,76 @@ function GalleryPreviewFields({
         value={(config.ctaHref as string) ?? ''}
         onChange={(v) => onUpdate({ ...config, ctaHref: v })}
       />
+    </div>
+  );
+}
+
+function NowFooterFields({
+  config,
+  onUpdate,
+}: {
+  config: Record<string, unknown>;
+  onUpdate: (c: Record<string, unknown>) => void;
+}) {
+  const items = (Array.isArray(config.thisWeek) ? config.thisWeek : []) as string[];
+
+  const updateItem = (index: number, value: string) => {
+    const next = [...items];
+    next[index] = value;
+    onUpdate({ ...config, thisWeek: next });
+  };
+
+  const addItem = () => onUpdate({ ...config, thisWeek: [...items, ''] });
+
+  const removeItem = (index: number) => {
+    const next = items.filter((_, i) => i !== index);
+    onUpdate({ ...config, thisWeek: next });
+  };
+
+  return (
+    <div>
+      <Field
+        label="Email de contacto"
+        value={(config.email as string) ?? ''}
+        onChange={(v) => onUpdate({ ...config, email: v })}
+      />
+      <div className="mt-3">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Lista "Esta semana"
+          </span>
+          <button
+            type="button"
+            onClick={addItem}
+            className="text-sm text-indigo-600 hover:underline"
+          >
+            + Añadir ítem
+          </button>
+        </div>
+        {items.length === 0 && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-2">
+            Sin ítems — se usarán los valores por defecto.
+          </p>
+        )}
+        {items.map((item, index) => (
+          <div key={index} className="mb-2 flex items-center gap-2">
+            <input
+              type="text"
+              value={item}
+              onChange={(e) => updateItem(index, e.target.value)}
+              placeholder={`Ítem ${index + 1}`}
+              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+            />
+            <button
+              type="button"
+              onClick={() => removeItem(index)}
+              className="text-sm text-red-500 hover:text-red-700"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/home/ActividadReciente.astro
+++ b/frontend/src/components/home/ActividadReciente.astro
@@ -4,6 +4,7 @@ import { fetchPublicAlbums } from '@utils/api-blog';
 import { fetchBooks } from '@/lib/api-books';
 import { getPostUrlBySlug } from '@utils/url-utils';
 import { getOptimizedImageUrl } from '@/lib/image-utils';
+import SpotifyChip from './SpotifyChip.tsx';
 
 let lastPost: { slug: string; title: string; image?: string } | null = null;
 let lastBook: { title: string; author: string; cover?: string; postSlug?: string; _id: string } | null = null;
@@ -16,9 +17,8 @@ try {
     fetchPublicAlbums(),
   ]);
 
-  if (posts.status === 'fulfilled' && posts.value?.length > 0) {
-    lastPost = posts.value[0];
-  }
+  if (posts.status === 'fulfilled' && posts.value?.length > 0) lastPost = posts.value[0];
+
   if (booksRaw.status === 'fulfilled' && booksRaw.value?.length > 0) {
     const sorted = [...booksRaw.value].sort((a, b) => {
       const dateA = a.readAt ?? a.createdAt;
@@ -27,71 +27,191 @@ try {
     });
     lastBook = sorted[0];
   }
+
   if (albumsRes.status === 'fulfilled') {
     const albums = albumsRes.value?.albums ?? [];
     if (albums.length > 0) lastAlbum = albums[0];
   }
 } catch (_) {}
-
-const items = [
-  lastPost && {
-    label: 'Último post',
-    title: lastPost.title,
-    href: getPostUrlBySlug(lastPost.slug),
-    image: lastPost.image ? getOptimizedImageUrl(lastPost.image, 120) : null,
-    icon: '✍️',
-    color: 'from-blue-500/10',
-  },
-  lastBook && {
-    label: 'Último libro',
-    title: `${lastBook.title} — ${lastBook.author}`,
-    href: lastBook.postSlug ? getPostUrlBySlug(lastBook.postSlug) : '/books/',
-    image: lastBook.cover ? getOptimizedImageUrl(lastBook.cover, 120) : null,
-    icon: '📖',
-    color: 'from-emerald-500/10',
-  },
-  lastAlbum && {
-    label: 'Último álbum',
-    title: lastAlbum.title,
-    href: `/gallery/${lastAlbum.slug}/`,
-    image: lastAlbum.coverImage ? getOptimizedImageUrl(lastAlbum.coverImage, 120) : null,
-    icon: '📷',
-    color: 'from-violet-500/10',
-  },
-].filter(Boolean);
 ---
 
-{items.length > 0 && (
-  <div class="w-full">
-    <p class="text-xs font-semibold uppercase tracking-widest text-[var(--deep-text)] opacity-60 mb-3 px-1">
-      Actividad reciente
-    </p>
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
-      {items.map((item) => (
-        <a
-          href={item!.href}
-          class={`group flex items-center gap-3 px-4 py-3 rounded-xl bg-gradient-to-r ${item!.color} to-transparent bg-[var(--card-bg)] border border-[var(--line-divider)] hover:border-[var(--primary)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md`}
-        >
-          {item!.image ? (
-            <img
-              src={item!.image}
-              alt={item!.title}
-              class="w-10 h-10 rounded-lg object-cover shrink-0 border border-[var(--line-divider)]"
-              loading="lazy"
-            />
-          ) : (
-            <span class="text-2xl shrink-0 w-10 text-center">{item!.icon}</span>
-          )}
-          <div class="min-w-0">
-            <p class="text-[0.68rem] font-semibold uppercase tracking-wider text-[var(--deep-text)] opacity-60">
-              {item!.label}
-            </p>
-            <p class="text-sm font-medium text-[var(--primary)] dark:text-[var(--title-active)] line-clamp-2 leading-snug group-hover:underline">
-              {item!.title}
-            </p>
-          </div>
-        </a>
-      ))}
-    </div>
+<div class="activity-strip">
+  <p class="activity-strip__label">Actividad reciente</p>
+
+  <div class="activity-strip__grid">
+    <!-- Music chip: React island with RAF visualizer -->
+    <SpotifyChip client:only="react" />
+
+    <!-- Book chip -->
+    {lastBook && (
+      <a
+        href={lastBook.postSlug ? getPostUrlBySlug(lastBook.postSlug) : '/books/'}
+        class="activity-chip activity-chip--book"
+      >
+        {lastBook.cover ? (
+          <img
+            src={getOptimizedImageUrl(lastBook.cover, 120)}
+            alt=""
+            class="activity-chip__img"
+            loading="lazy"
+          />
+        ) : (
+          <span class="activity-chip__icon" aria-hidden="true">📖</span>
+        )}
+        <span class="activity-chip__body">
+          <span class="activity-chip__tag">Último libro</span>
+          <span class="activity-chip__title">{lastBook.title}</span>
+          <span class="activity-chip__sub">{lastBook.author}</span>
+        </span>
+        <!-- Book progress bar (static at ~60% as placeholder) -->
+        <span class="activity-chip__progress" aria-hidden="true">
+          <span class="activity-chip__progress-bar"></span>
+        </span>
+      </a>
+    )}
+
+    <!-- Album chip -->
+    {lastAlbum && (
+      <a href={`/gallery/${lastAlbum.slug}/`} class="activity-chip activity-chip--album">
+        {lastAlbum.coverImage ? (
+          <img
+            src={getOptimizedImageUrl(lastAlbum.coverImage, 120)}
+            alt=""
+            class="activity-chip__img"
+            loading="lazy"
+          />
+        ) : (
+          <span class="activity-chip__icon" aria-hidden="true">📷</span>
+        )}
+        <span class="activity-chip__body">
+          <span class="activity-chip__tag">Último álbum</span>
+          <span class="activity-chip__title">{lastAlbum.title}</span>
+        </span>
+        <span class="activity-chip__arrow" aria-hidden="true">→</span>
+      </a>
+    )}
   </div>
-)}
+</div>
+
+<style>
+  .activity-strip {
+    width: 100%;
+  }
+
+  .activity-strip__label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--deep-text);
+    opacity: 0.55;
+    margin: 0 0 0.6rem 0.15rem;
+  }
+
+  .activity-strip__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  @media (min-width: 560px) {
+    .activity-strip__grid { grid-template-columns: repeat(3, 1fr); }
+  }
+
+  /* ── Shared chip styles ── */
+  .activity-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 0.75rem;
+    background: var(--card-bg);
+    border: 1px solid var(--line-divider);
+    text-decoration: none;
+    transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  }
+  .activity-chip:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px -4px rgb(0 0 0 / 0.12);
+  }
+  .activity-chip--book:hover  { border-color: #10b981; box-shadow: 0 4px 16px -4px rgba(16,185,129,0.25); }
+  .activity-chip--album:hover { border-color: #818cf8; box-shadow: 0 4px 16px -4px rgba(129,140,248,0.25); }
+
+  .activity-chip__img {
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 0.4rem;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .activity-chip__icon {
+    font-size: 1.4rem;
+    flex-shrink: 0;
+    line-height: 1;
+  }
+
+  .activity-chip__body {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    flex: 1;
+    gap: 0.05rem;
+  }
+
+  .activity-chip__tag {
+    font-size: 0.63rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--deep-text);
+    opacity: 0.6;
+  }
+
+  .activity-chip__title {
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: var(--primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1.3;
+  }
+  .activity-chip:hover .activity-chip__title { text-decoration: underline; }
+
+  .activity-chip__sub {
+    font-size: 0.72rem;
+    color: var(--deep-text);
+    opacity: 0.7;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .activity-chip__arrow {
+    font-size: 0.9rem;
+    color: var(--primary);
+    flex-shrink: 0;
+    transition: transform 0.2s ease;
+  }
+  .activity-chip:hover .activity-chip__arrow { transform: translateX(3px); }
+
+  /* Book progress bar */
+  .activity-chip__progress {
+    display: block;
+    width: 3px;
+    height: 2rem;
+    border-radius: 9999px;
+    background: rgba(16,185,129,0.15);
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+  .activity-chip__progress-bar {
+    display: block;
+    width: 100%;
+    height: 60%;
+    background: #10b981;
+    border-radius: 9999px;
+    margin-top: auto;
+  }
+</style>

--- a/frontend/src/components/home/GalleryPreview.astro
+++ b/frontend/src/components/home/GalleryPreview.astro
@@ -1,6 +1,7 @@
 ---
 import { fetchPublicAlbums } from '@utils/api-blog';
 import { getOptimizedImageUrl } from '@/lib/image-utils';
+import type { GalleryAlbum } from '@utils/api-blog';
 
 interface Props {
   config?: Record<string, unknown>;
@@ -8,63 +9,169 @@ interface Props {
 
 const { config = {} } = Astro.props;
 
-const title = (config.title as string) ?? 'Galería';
+const title   = (config.title as string)   ?? 'Galería';
 const ctaText = (config.ctaText as string) ?? 'Ver galería completa';
 const ctaHref = (config.ctaHref as string) ?? '/gallery/';
-const albumSlugs = (config.albumSlugs as string[] | undefined) ?? [];
 
-let albums: Array<{ slug: string; title: string; coverImage?: string; images?: unknown[] }> = [];
+const albumSlugsFilter = Array.isArray(config.albumSlugs) ? config.albumSlugs as string[] : [];
+
+let albums: GalleryAlbum[] = [];
 try {
   const res = await fetchPublicAlbums();
-  const all = res.albums ?? [];
-  if (albumSlugs.length > 0) {
-    albums = albumSlugs
-      .map((slug) => all.find((a: { slug: string }) => a.slug === slug))
-      .filter(Boolean) as typeof albums;
-  } else {
-    albums = all.slice(0, 2);
+  albums = res?.albums ?? [];
+  if (albumSlugsFilter.length > 0) {
+    albums = albums.filter((a) => albumSlugsFilter.includes(a.slug));
   }
-} catch (e) {
-  console.error('[GalleryPreview] Error al obtener álbumes:', e);
-}
-
-function getImageUrl(url: string | undefined, version?: number): string {
-  if (!url) return '/default-avatar.svg';
-  return getOptimizedImageUrl(url, 400, 80, version ?? 0);
-}
+  albums = albums.slice(0, 2);
+} catch (_) {}
 ---
 
-<section class="w-full py-16 bg-[var(--card-bg)] text-center rounded-[var(--radius-large)] shadow-md">
-    <div class="max-w-5xl mx-auto px-6">
-        <h2 class="text-3xl font-bold text-[var(--primary)] dark:text-[var(--title-active)]">{title}</h2>
-    </div>
-    {albums.length > 0 ? (
-      <div class="mt-8 max-w-5xl mx-auto px-6">
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          {albums.slice(0, 4).map((album) => {
-            const firstImg = Array.isArray(album.images) && album.images[0] && typeof album.images[0] === 'object' && album.images[0] !== null
-              ? (album.images[0] as { url?: string; orientation?: number })
-              : null;
-            const cover = album.coverImage ?? firstImg?.url ?? null;
-            const coverOrientation = firstImg?.orientation ?? 0;
-            const coverUrl = getImageUrl(cover ?? undefined, coverOrientation);
-            return (
-              <a href={`/gallery/${album.slug}`} class="group block aspect-square rounded-lg overflow-hidden bg-[var(--btn-regular-bg)] transition-all duration-300 hover:scale-[1.02] hover:shadow-lg">
-                <img src={coverUrl} alt={album.title} class="w-full h-full object-cover transition duration-300 group-hover:scale-105" loading="lazy" />
-              </a>
-            );
-          })}
+<section class="gallery-teaser">
+  <div class="gallery-teaser__header">
+    <h2 class="gallery-teaser__title">{title}</h2>
+    <a href={ctaHref} class="gallery-teaser__cta-inline">
+      {ctaText} <span aria-hidden="true">→</span>
+    </a>
+  </div>
+
+  <div class="gallery-teaser__grid">
+    {albums.length > 0 ? albums.map((album) => {
+      const cover = album.coverImage ? getOptimizedImageUrl(album.coverImage, 800) : null;
+      return (
+        <a href={`/gallery/${album.slug}/`} class="gallery-photo" aria-label={album.title}>
+          {cover ? (
+            <img src={cover} alt={album.title} class="gallery-photo__img" loading="lazy" />
+          ) : (
+            <div class="gallery-photo__placeholder" aria-hidden="true">📷</div>
+          )}
+          <div class="gallery-photo__caption">
+            <span>{album.title}</span>
+            <span class="gallery-photo__arrow" aria-hidden="true">→</span>
+          </div>
+        </a>
+      );
+    }) : (
+      <a href={ctaHref} class="gallery-photo gallery-photo--cta">
+        <div class="gallery-photo__placeholder" aria-hidden="true">📷</div>
+        <div class="gallery-photo__caption">
+          <span>Ver galería</span>
+          <span class="gallery-photo__arrow" aria-hidden="true">→</span>
         </div>
-        <div class="mt-6 text-center">
-          <a href={ctaHref} class="inline-block px-6 py-3 bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] text-[var(--btn-content)] rounded-lg font-semibold transition-all duration-300 hover:scale-105 hover:shadow-md">
-            {ctaText}
-          </a>
-        </div>
-      </div>
-    ) : (
-      <div class="mt-8 max-w-5xl mx-auto px-6">
-        <p class="text-[var(--deep-text)] dark:text-gray-400">No hay álbumes disponibles.</p>
-        <a href={ctaHref} class="mt-4 inline-block text-[var(--primary)] font-medium hover:underline">{ctaText}</a>
-      </div>
+      </a>
     )}
+  </div>
 </section>
+
+<style>
+  .gallery-teaser {
+    width: 100%;
+    padding: 2.5rem 1.5rem;
+    background: var(--card-bg);
+    border-radius: var(--radius-large);
+    box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+  }
+
+  .gallery-teaser__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .gallery-teaser__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--primary);
+    margin: 0;
+  }
+
+  .gallery-teaser__cta-inline {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--btn-content);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    background: var(--btn-regular-bg);
+    transition: background 0.2s, transform 0.2s;
+    flex-shrink: 0;
+  }
+  .gallery-teaser__cta-inline:hover { background: var(--btn-regular-bg-hover); transform: translateY(-1px); }
+  .gallery-teaser__cta-inline:focus-visible { outline: 2px solid var(--primary); outline-offset: 4px; }
+
+  .gallery-teaser__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  @media (min-width: 480px) { .gallery-teaser__grid { grid-template-columns: repeat(2, 1fr); } }
+
+  /* Photo card */
+  .gallery-photo {
+    position: relative;
+    display: block;
+    border-radius: 0.875rem;
+    overflow: hidden;
+    aspect-ratio: 4 / 3;
+    background: var(--btn-regular-bg);
+    text-decoration: none;
+  }
+
+  .gallery-photo__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: grayscale(100%);
+    transition: filter 0.45s ease, transform 0.45s ease;
+    display: block;
+  }
+  .gallery-photo:hover .gallery-photo__img {
+    filter: grayscale(0%);
+    transform: scale(1.04);
+  }
+
+  .gallery-photo__placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 3rem;
+    opacity: 0.3;
+  }
+
+  .gallery-photo__caption {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 0.75rem 1rem;
+    background: linear-gradient(to top, rgba(0,0,0,0.75) 0%, transparent 100%);
+    color: white;
+    font-size: 0.85rem;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    transform: translateY(5px);
+    opacity: 0;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+  .gallery-photo:hover .gallery-photo__caption { transform: translateY(0); opacity: 1; }
+
+  .gallery-photo__arrow { transition: transform 0.2s ease; }
+  .gallery-photo:hover .gallery-photo__arrow { transform: translateX(3px); }
+
+  .gallery-photo--cta { opacity: 0.6; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .gallery-photo__img      { transition: none; filter: none; }
+    .gallery-photo:hover .gallery-photo__img { transform: none; filter: none; }
+    .gallery-photo__caption  { opacity: 1; transform: none; transition: none; }
+  }
+</style>

--- a/frontend/src/components/home/Hero.astro
+++ b/frontend/src/components/home/Hero.astro
@@ -12,8 +12,9 @@ const title = (config.title as string) ?? 'Desarrollo, Fotografía y Reflexión'
 const subtitle =
   (config.subtitle as string) ??
   'Desarrollo soluciones. Capturo momentos. Reflexiono sobre historias. Aquí es donde todo converge.';
-const ctaText = (config.ctaText as string) ?? 'Explorar';
-const ctaHref = (config.ctaHref as string) ?? '#explore';
+const ctaText  = (config.ctaText  as string) ?? 'Explorar';
+const ctaHref  = (config.ctaHref  as string) ?? '#explore';
+const eyebrow  = (config.eyebrow  as string) ?? 'BRYAN F. MUÑOZ M. · BOGOTÁ';
 const carouselIntervalSeconds =
   typeof config.carouselIntervalSeconds === 'number' ? config.carouselIntervalSeconds : 5.5;
 const heightVh =
@@ -65,10 +66,12 @@ const intervalMs = Math.max(2000, Math.min(30000, carouselIntervalSeconds * 1000
 
   <!-- Content -->
   <div class="hero__overlay">
-    <div class="hero__eyebrow">
-      <span class="hero__eyebrow-dot" aria-hidden="true"></span>
-      <span>BRYAN F. MUÑOZ M. · BOGOTÁ</span>
-    </div>
+    {eyebrow && (
+      <div class="hero__eyebrow">
+        <span class="hero__eyebrow-dot" aria-hidden="true"></span>
+        <span>{eyebrow}</span>
+      </div>
+    )}
 
     <h1 class="hero__title" data-word-reveal data-text={title}>{title}</h1>
 

--- a/frontend/src/components/home/Hero.astro
+++ b/frontend/src/components/home/Hero.astro
@@ -9,11 +9,15 @@ interface Props {
 const { config = {} } = Astro.props;
 
 const title = (config.title as string) ?? 'Desarrollo, Fotografía y Reflexión';
-const subtitle = (config.subtitle as string) ?? 'Desarrollo soluciones. Capturo momentos. Reflexiono sobre historias. Aquí es donde todo converge.';
+const subtitle =
+  (config.subtitle as string) ??
+  'Desarrollo soluciones. Capturo momentos. Reflexiono sobre historias. Aquí es donde todo converge.';
 const ctaText = (config.ctaText as string) ?? 'Explorar';
 const ctaHref = (config.ctaHref as string) ?? '#explore';
-const carouselIntervalSeconds = typeof config.carouselIntervalSeconds === 'number' ? config.carouselIntervalSeconds : 5.5;
-const heightVh = typeof config.heightVh === 'number' ? Math.max(30, Math.min(100, config.heightVh)) : 70;
+const carouselIntervalSeconds =
+  typeof config.carouselIntervalSeconds === 'number' ? config.carouselIntervalSeconds : 5.5;
+const heightVh =
+  typeof config.heightVh === 'number' ? Math.max(30, Math.min(100, config.heightVh)) : 70;
 
 const defaultBannerUrl = typeof bannerImage === 'string' ? bannerImage : bannerImage.src;
 
@@ -22,8 +26,8 @@ function resolveUrl(url: string): string {
   return getOptimizedImageUrl(url, 2560, 90);
 }
 
-const imageUrlLegacy = config.imageUrl as string | undefined;
 const imageUrlsRaw = (config.imageUrls as string[] | undefined) ?? [];
+const imageUrlLegacy = config.imageUrl as string | undefined;
 
 let imageUrls: string[];
 if (imageUrlsRaw.length > 0) {
@@ -45,7 +49,8 @@ const intervalMs = Math.max(2000, Math.min(30000, carouselIntervalSeconds * 1000
   data-slides-count={slides.length}
   style={`--hero-height: ${heightVh}vh;`}
 >
-  <div class="hero__bg" aria-hidden="true">
+  <!-- Parallax background -->
+  <div class="hero__bg" data-parallax-bg aria-hidden="true">
     {slides.map((url, i) => (
       <div
         class:list={['hero__slide', { 'is-active': i === 0 }]}
@@ -55,12 +60,40 @@ const intervalMs = Math.max(2000, Math.min(30000, carouselIntervalSeconds * 1000
     ))}
   </div>
 
+  <!-- Gradient vignette -->
+  <div class="hero__vignette" aria-hidden="true"></div>
+
+  <!-- Content -->
   <div class="hero__overlay">
-    <h1 class="hero__title">{title}</h1>
-    <p class="hero__subtitle">{subtitle}</p>
-    <a href={ctaHref} class="hero__cta">{ctaText}</a>
+    <div class="hero__eyebrow">
+      <span class="hero__eyebrow-dot" aria-hidden="true"></span>
+      <span>BRYAN F. MUÑOZ M. · BOGOTÁ</span>
+    </div>
+
+    <h1 class="hero__title" data-word-reveal data-text={title}>{title}</h1>
+
+    <p class="hero__subtitle" data-subtitle-reveal>{subtitle}</p>
+
+    <div class="hero__cta-wrap">
+      <a href={ctaHref} class="hero__cta" data-magnetic>{ctaText}</a>
+    </div>
   </div>
 
+  <!-- Scroll cue -->
+  <button
+    class="hero__scroll-cue"
+    data-scroll-cue
+    type="button"
+    aria-label="Desplazarse hacia abajo"
+    onclick={`document.querySelector('${ctaHref}')?.scrollIntoView({behavior:'smooth'})`}
+  >
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2.5"
+      stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M6 9l6 6 6-6"/>
+    </svg>
+  </button>
+
+  <!-- Carousel dots -->
   {slides.length > 1 && (
     <div class="hero__dots" aria-label="Slides del carrusel">
       {slides.map((_, i) => (
@@ -83,14 +116,16 @@ const intervalMs = Math.max(2000, Math.min(30000, carouselIntervalSeconds * 1000
     min-height: var(--hero-height, 70vh);
     overflow: hidden;
     border-radius: var(--radius-large, 1rem);
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+    box-shadow: 0 4px 32px -8px rgb(0 0 0 / 0.25);
   }
 
+  /* BG oversized for parallax headroom */
   .hero__bg {
     position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
+    inset: -6%;
+    width: 112%;
+    height: 112%;
+    will-change: transform;
   }
 
   .hero__slide {
@@ -102,94 +137,215 @@ const intervalMs = Math.max(2000, Math.min(30000, carouselIntervalSeconds * 1000
     background-position: center;
     background-repeat: no-repeat;
     opacity: 0;
-    transition: opacity 0.7s ease;
+    transition: opacity 0.8s ease;
   }
+  .hero__slide.is-active { opacity: 1; }
 
-  .hero__slide.is-active {
-    opacity: 1;
+  /* Darker gradient at bottom for title legibility */
+  .hero__vignette {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      160deg,
+      rgba(0,0,0,0.28) 0%,
+      rgba(0,0,0,0.55) 50%,
+      rgba(0,0,0,0.72) 100%
+    );
+    pointer-events: none;
+    z-index: 1;
   }
 
   .hero__overlay {
     position: absolute;
     inset: 0;
-    width: 100%;
-    height: 100%;
+    z-index: 2;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     text-align: center;
-    padding: 1.5rem;
-    background: rgba(0, 0, 0, 0.5);
-    border-radius: var(--radius-large, 1rem);
+    padding: 2rem 1.5rem 5rem;
+    pointer-events: none;
   }
 
+  /* Eyebrow pill */
+  .hero__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 1.1rem;
+    border-radius: 9999px;
+    background: rgba(255,255,255,0.12);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border: 1px solid rgba(255,255,255,0.22);
+    color: rgba(255,255,255,0.92);
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    margin-bottom: 1.4rem;
+    animation: eyebrow-in 0.55s cubic-bezier(0.22,1,0.36,1) both;
+  }
+
+  .hero__eyebrow-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 9999px;
+    background: #22d3ee;
+    box-shadow: 0 0 7px #22d3ee;
+    flex-shrink: 0;
+    animation: dot-pulse 2.2s ease-in-out infinite;
+  }
+
+  /* Title words are injected by hero-animations.ts */
   .hero__title {
-    font-size: 2.25rem;
+    font-size: clamp(1.9rem, 5vw, 3.8rem);
     font-weight: 700;
     color: white;
-    text-shadow: 0 1px 2px rgb(0 0 0 / 0.5);
+    text-shadow: 0 2px 16px rgb(0 0 0 / 0.45);
     margin: 0;
+    line-height: 1.18;
+    max-width: 54rem;
   }
 
-  @media (min-width: 768px) {
-    .hero__title {
-      font-size: 3.75rem;
-    }
+  /* Word span styles (global so JS-injected spans pick them up) */
+  :global(.hw) {
+    display: inline-block;
+    opacity: 0;
+    filter: blur(5px);
+    transform: translateY(18px);
+    transition: opacity 0.42s ease, filter 0.42s ease, transform 0.42s ease;
+  }
+  :global(.hw--v) {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
   }
 
+  /* Subtitle */
   .hero__subtitle {
-    font-size: 1.125rem;
-    color: rgba(255, 255, 255, 0.9);
+    font-size: clamp(0.95rem, 2vw, 1.1rem);
+    color: rgba(255,255,255,0.87);
     max-width: 42rem;
-    margin: 1rem 0 0;
+    margin: 1.25rem 0 0;
+    line-height: 1.65;
+    opacity: 0;
+    transform: translateY(14px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+  }
+  .hero__subtitle--v {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  /* CTA */
+  .hero__cta-wrap {
+    margin-top: 2.25rem;
+    pointer-events: auto;
   }
 
   .hero__cta {
-    margin-top: 1.5rem;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.5rem;
-    font-size: 1.125rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.8rem 2.2rem;
+    border-radius: 9999px;
+    font-size: 1rem;
     font-weight: 600;
-    background: var(--btn-regular-bg);
-    color: var(--btn-content);
+    background: rgba(6,182,212,0.92);
+    color: white;
     text-decoration: none;
-    transition: transform 0.2s, box-shadow 0.2s;
+    will-change: transform;
+    transition: transform 0.22s cubic-bezier(0.34,1.56,0.64,1),
+                box-shadow 0.22s ease,
+                background 0.18s ease;
+    box-shadow: 0 4px 24px -6px rgba(6,182,212,0.55);
+    letter-spacing: 0.01em;
   }
-
   .hero__cta:hover {
-    transform: scale(1.05);
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+    background: rgb(6,182,212);
+    box-shadow: 0 8px 32px -6px rgba(6,182,212,0.7);
+  }
+  .hero__cta:focus-visible {
+    outline: 2px solid #22d3ee;
+    outline-offset: 4px;
   }
 
-  .hero__dots {
+  /* Scroll cue */
+  .hero__scroll-cue {
     position: absolute;
-    bottom: 1rem;
+    bottom: 1.75rem;
     left: 50%;
     transform: translateX(-50%);
+    z-index: 3;
     display: flex;
-    gap: 0.5rem;
-    z-index: 10;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border: none;
+    background: rgba(255,255,255,0.16);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    border-radius: 9999px;
+    cursor: pointer;
+    opacity: 1;
+    transition: opacity 0.4s ease, background 0.2s;
+    animation: scroll-bounce 2.4s ease-in-out infinite;
+  }
+  .hero__scroll-cue:hover { background: rgba(255,255,255,0.28); }
+  .hero__scroll-cue:focus-visible { outline: 2px solid white; outline-offset: 3px; }
+
+  /* Dots — hidden if scroll-cue visible (bottom space shared) */
+  .hero__dots {
+    position: absolute;
+    bottom: 1.25rem;
+    right: 1.5rem;
+    display: flex;
+    gap: 0.45rem;
+    z-index: 3;
   }
 
   .hero__dot {
-    width: 0.5rem;
-    height: 0.5rem;
+    width: 0.45rem;
+    height: 0.45rem;
     border-radius: 9999px;
     border: none;
     padding: 0;
     cursor: pointer;
-    background: rgba(255, 255, 255, 0.5);
-    transition: width 0.3s, background 0.3s;
+    background: rgba(255,255,255,0.45);
+    transition: width 0.3s ease, background 0.3s ease;
+  }
+  .hero__dot.is-active {
+    width: 1.4rem;
+    background: white;
   }
 
-  .hero__dot.is-active {
-    width: 1.5rem;
-    background: white;
+  /* Keyframes */
+  @keyframes eyebrow-in {
+    from { opacity: 0; transform: translateY(-14px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  @keyframes dot-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); box-shadow: 0 0 7px #22d3ee; }
+    50%       { opacity: 0.55; transform: scale(0.75); box-shadow: 0 0 3px #22d3ee; }
+  }
+  @keyframes scroll-bounce {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50%       { transform: translateX(-50%) translateY(7px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero__eyebrow, .hero__eyebrow-dot, .hero__scroll-cue { animation: none; }
+    :global(.hw)          { opacity: 1 !important; filter: none !important; transform: none !important; transition: none !important; }
+    .hero__subtitle       { opacity: 1 !important; transform: none !important; transition: none !important; }
   }
 </style>
 
 <script data-swup-reload-script>
   import { initHeroPage } from '../../lib/hero-init';
+  import { initHeroAnimations } from '../../lib/hero-animations';
   initHeroPage();
+  initHeroAnimations();
 </script>

--- a/frontend/src/components/home/HomeSection.astro
+++ b/frontend/src/components/home/HomeSection.astro
@@ -68,7 +68,7 @@ const staggerDelay = index * 80;
 {section.id === 'now-footer' && (
   <ScrollReveal delay={staggerDelay} class="mb-12">
     <section>
-      <NowFooter />
+      <NowFooter config={section.config} />
     </section>
   </ScrollReveal>
 )}

--- a/frontend/src/components/home/HomeSection.astro
+++ b/frontend/src/components/home/HomeSection.astro
@@ -5,8 +5,8 @@ import SeccionesGrid from './SeccionesGrid.astro';
 import GalleryPreview from './GalleryPreview.astro';
 import UltimosPosts from './UltimosPosts.astro';
 import ActividadReciente from './ActividadReciente.astro';
+import NowFooter from './NowFooter.astro';
 import ScrollReveal from './ScrollReveal.astro';
-import NowListening from './NowListening.tsx';
 import type { HomepageSection } from './componentRegistry';
 
 interface Props {
@@ -54,7 +54,7 @@ const staggerDelay = index * 80;
 {section.id === 'now-listening' && (
   <ScrollReveal delay={staggerDelay} class="mb-12">
     <section>
-      <NowListening client:only="react" />
+      <ActividadReciente />
     </section>
   </ScrollReveal>
 )}
@@ -62,6 +62,13 @@ const staggerDelay = index * 80;
   <ScrollReveal delay={staggerDelay} class="mb-12">
     <section>
       <ActividadReciente />
+    </section>
+  </ScrollReveal>
+)}
+{section.id === 'now-footer' && (
+  <ScrollReveal delay={staggerDelay} class="mb-12">
+    <section>
+      <NowFooter />
     </section>
   </ScrollReveal>
 )}

--- a/frontend/src/components/home/IntroPersonal.astro
+++ b/frontend/src/components/home/IntroPersonal.astro
@@ -1,8 +1,8 @@
 ---
-import { profileConfig } from '@/config';
 import { getOptimizedImageUrl } from '@/lib/image-utils';
 import { fetchPosts } from '@utils/api-blog';
 import { fetchPublicAlbums } from '@utils/api-blog';
+import { fetchBooks } from '@/lib/api-books';
 import profileAvatar from '@/assets/images/DSC_1024.jpg';
 
 interface Props {
@@ -11,10 +11,10 @@ interface Props {
 
 const { config = {} } = Astro.props;
 
-const title = (config.title as string) ?? '¡Hola! Soy Bryan Muñoz';
-const bio = (config.bio as string) ?? 'Bienvenido a mi espacio digital, donde comparto mis proyectos, ideas y pasiones. Aquí podrás explorar mi portafolio de desarrollo, aprender con mis artículos técnicos, descubrir mis fotografías y reflexiones sobre libros y música. ¡Espero que encuentres algo que te inspire!';
-const ctaText = (config.ctaText as string) ?? 'Ver mi trabajo';
-const ctaHref = (config.ctaHref as string) ?? '#work';
+const title   = (config.title as string)   ?? '¡Hola! Soy Bryan Muñoz';
+const bio     = (config.bio as string)     ?? 'Bienvenido a mi espacio digital, donde comparto mis proyectos, ideas y pasiones. Aquí podrás explorar mi portafolio de desarrollo, aprender con mis artículos técnicos, descubrir mis fotografías y reflexiones sobre libros y música.';
+const ctaText = (config.ctaText as string) ?? 'Ver portafolio';
+const ctaHref = (config.ctaHref as string) ?? 'https://portfolio.bfmu.dev';
 
 let avatarUrl: string;
 const configAvatar = config.avatarUrl as string | undefined;
@@ -26,41 +26,286 @@ if (configAvatar && (configAvatar.startsWith('http') || configAvatar.startsWith(
 
 let postsCount = 0;
 let albumsCount = 0;
+let booksCount = 0;
 try {
-  const [postsRes, albumsRes] = await Promise.all([
+  const [postsRes, albumsRes, booksRes] = await Promise.all([
     fetchPosts({ limit: 1, page: 1 }).catch(() => ({ pagination: { total: 0 } })),
-    fetchPublicAlbums().catch(() => ({ pagination: { total: 0 } })),
+    fetchPublicAlbums().catch(() => ({ albums: [], pagination: { total: 0 } })),
+    fetchBooks().catch(() => [] as any[]),
   ]);
-  postsCount = postsRes.pagination?.total ?? 0;
+  postsCount  = postsRes.pagination?.total ?? 0;
   albumsCount = albumsRes.pagination?.total ?? 0;
+  booksCount  = Array.isArray(booksRes) ? booksRes.length : 0;
 } catch (_) {}
+
+const isExternal = ctaHref.startsWith('http');
 ---
 
-<section class="w-full py-16 bg-[var(--card-bg)] rounded-[var(--radius-large)] shadow-md">
-    <div class="max-w-4xl mx-auto px-6 flex flex-col md:flex-row md:items-center md:gap-10">
-        <div class="flex justify-center md:justify-start md:shrink-0">
-            <img
-                src={avatarUrl}
-                alt={title}
-                class="w-28 h-28 md:w-36 md:h-36 rounded-full object-cover border-4 border-[var(--btn-regular-bg)] shadow-lg"
-                loading="lazy"
-            />
-        </div>
-        <div class="text-center md:text-left mt-6 md:mt-0 flex-1">
-            <h2 class="text-3xl font-bold text-[var(--primary)] dark:text-[var(--title-active)]">{title}</h2>
-            <p class="text-lg text-[var(--deep-text)] dark:text-white mt-4">
-                {bio}
-            </p>
-            <div class="flex flex-wrap gap-4 justify-center md:justify-start mt-4 text-sm text-[var(--deep-text)] dark:text-gray-300">
-                <span>{postsCount} artículos</span>
-                <span>{albumsCount} álbumes</span>
-            </div>
-            <div class="mt-6">
-                <a href={ctaHref} class="intro-cta inline-flex items-center gap-2 px-6 py-3 bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] text-[var(--btn-content)] rounded-lg text-lg font-semibold transition-all duration-300 group">
-                    {ctaText}
-                    <span class="inline-block transition-transform duration-300 group-hover:translate-x-1">→</span>
-                </a>
-            </div>
-        </div>
+<section class="about-card" id="explore">
+  <div class="about-card__inner">
+
+    <!-- Avatar -->
+    <div class="about-card__avatar-wrap" aria-hidden="true">
+      <span class="about-card__ring"></span>
+      <img
+        src={avatarUrl}
+        alt="Foto de Bryan Muñoz"
+        class="about-card__avatar"
+        loading="lazy"
+        width="144"
+        height="144"
+      />
     </div>
+
+    <!-- Content -->
+    <div class="about-card__body">
+      <h2 class="about-card__name">
+        {title}<span class="about-card__cursor" aria-hidden="true">_</span>
+      </h2>
+
+      <p class="about-card__bio">{bio}</p>
+
+      <!-- Stats: count-up animation on scroll -->
+      <div class="about-card__stats" data-stats-root>
+        <div class="about-card__stat" data-count={postsCount}>
+          <span class="about-card__stat-num" data-stat-num>0</span>
+          <span class="about-card__stat-label">artículos</span>
+        </div>
+        <div class="about-card__stat" data-count={albumsCount}>
+          <span class="about-card__stat-num" data-stat-num>0</span>
+          <span class="about-card__stat-label">álbumes</span>
+        </div>
+        <div class="about-card__stat" data-count={booksCount}>
+          <span class="about-card__stat-num" data-stat-num>0</span>
+          <span class="about-card__stat-label">libros</span>
+        </div>
+      </div>
+
+      <a
+        href={ctaHref}
+        class="about-card__cta"
+        target={isExternal ? '_blank' : undefined}
+        rel={isExternal ? 'noopener noreferrer' : undefined}
+      >
+        {ctaText}
+        <span class="about-card__arrow" aria-hidden="true">→</span>
+      </a>
+    </div>
+  </div>
 </section>
+
+<style>
+  .about-card {
+    width: 100%;
+    padding: 3rem 1.5rem;
+    background: var(--card-bg);
+    border-radius: var(--radius-large);
+    box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+  }
+
+  .about-card__inner {
+    max-width: 52rem;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
+  }
+
+  @media (min-width: 560px) {
+    .about-card__inner {
+      flex-direction: row;
+      align-items: flex-start;
+      gap: 2.5rem;
+    }
+    .about-card__body { text-align: left; }
+    .about-card__stats { justify-content: flex-start; }
+    .about-card__stat  { align-items: flex-start; }
+  }
+
+  /* ── Avatar ── */
+  .about-card__avatar-wrap {
+    position: relative;
+    flex-shrink: 0;
+    width: 9rem;
+    height: 9rem;
+  }
+
+  /* Rotating conic ring */
+  .about-card__ring {
+    position: absolute;
+    inset: -4px;
+    border-radius: 9999px;
+    background: conic-gradient(from 0deg, #06b6d4 0%, #818cf8 50%, #06b6d4 100%);
+    animation: ring-spin 7s linear infinite;
+    z-index: 0;
+  }
+  /* Mask the inner part to show only the ring */
+  .about-card__ring::after {
+    content: '';
+    position: absolute;
+    inset: 3px;
+    border-radius: 9999px;
+    background: var(--card-bg);
+  }
+
+  .about-card__avatar {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border-radius: 9999px;
+    object-fit: cover;
+    filter: grayscale(100%);
+    transition: filter 0.45s ease, transform 0.35s ease;
+    z-index: 1;
+    cursor: default;
+  }
+  .about-card__avatar-wrap:hover .about-card__avatar {
+    filter: grayscale(0%);
+    transform: scale(1.04);
+  }
+
+  /* ── Body ── */
+  .about-card__body { flex: 1; text-align: center; }
+
+  .about-card__name {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--primary);
+    margin: 0 0 0.85rem;
+    line-height: 1.2;
+  }
+
+  /* Blinking underscore cursor */
+  .about-card__cursor {
+    display: inline-block;
+    color: #06b6d4;
+    font-weight: 700;
+    animation: cursor-blink 1.1s step-end infinite;
+    margin-left: 1px;
+    user-select: none;
+  }
+
+  .about-card__bio {
+    font-size: 1rem;
+    color: var(--deep-text);
+    line-height: 1.72;
+    margin: 0 0 1.5rem;
+  }
+
+  /* ── Stats ── */
+  .about-card__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.75rem;
+    justify-content: center;
+    margin-bottom: 1.75rem;
+  }
+
+  .about-card__stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.1rem;
+  }
+
+  .about-card__stat-num {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--primary);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  .about-card__stat-label {
+    font-size: 0.7rem;
+    color: var(--deep-text);
+    opacity: 0.65;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+  }
+
+  /* ── CTA ── */
+  .about-card__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1.6rem;
+    border-radius: 9999px;
+    background: var(--btn-regular-bg);
+    color: var(--btn-content);
+    font-weight: 600;
+    font-size: 0.95rem;
+    text-decoration: none;
+    transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  }
+  .about-card__cta:hover {
+    background: var(--btn-regular-bg-hover);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 14px -4px rgb(0 0 0 / 0.15);
+  }
+  .about-card__cta:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 4px;
+  }
+
+  .about-card__arrow {
+    display: inline-block;
+    transition: transform 0.2s ease;
+  }
+  .about-card__cta:hover .about-card__arrow { transform: translateX(4px); }
+
+  /* ── Keyframes ── */
+  @keyframes ring-spin {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+  }
+  @keyframes cursor-blink {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .about-card__ring   { animation: none; }
+    .about-card__cursor { animation: none; opacity: 1; }
+    .about-card__avatar { filter: none; transition: none; }
+  }
+</style>
+
+<script data-swup-reload-script>
+  function easeOutCubic(t: number) { return 1 - Math.pow(1 - t, 3); }
+
+  function countUp(el: HTMLElement, target: number, duration = 1300) {
+    const start = performance.now();
+    (function step(now: number) {
+      const p = Math.min((now - start) / duration, 1);
+      el.textContent = String(Math.round(easeOutCubic(p) * target));
+      if (p < 1) requestAnimationFrame(step);
+    })(performance.now());
+  }
+
+  function initCountStats() {
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const root = document.querySelector<HTMLElement>('[data-stats-root]');
+    if (!root) return;
+
+    const stats = root.querySelectorAll<HTMLElement>('[data-count]');
+
+    const obs = new IntersectionObserver((entries) => {
+      if (!entries[0].isIntersecting) return;
+      stats.forEach((stat) => {
+        const target = parseInt(stat.dataset.count ?? '0', 10);
+        const num = stat.querySelector<HTMLElement>('[data-stat-num]');
+        if (!num) return;
+        if (reduced) { num.textContent = String(target); return; }
+        countUp(num, target);
+      });
+      obs.disconnect();
+    }, { threshold: 0.3 });
+
+    obs.observe(root);
+  }
+
+  initCountStats();
+</script>

--- a/frontend/src/components/home/NowFooter.astro
+++ b/frontend/src/components/home/NowFooter.astro
@@ -1,14 +1,23 @@
 ---
 import { profileConfig } from '@/config';
 
-// "Esta semana" — actualizar manualmente o conectar a una API de notion/obsidian en el futuro
-const thisWeek = [
+interface Props {
+  config?: Record<string, unknown>;
+}
+
+const { config = {} } = Astro.props;
+
+const defaultWeek = [
   'Explorando NestJS guards y decoradores personalizados',
   'Leyendo sobre sistemas distribuidos',
   'Fotografiando en las calles del centro de Bogotá',
 ];
 
-const email = 'bfmumo@gmail.com';
+const thisWeek = (Array.isArray(config.thisWeek) && config.thisWeek.length > 0)
+  ? (config.thisWeek as string[])
+  : defaultWeek;
+
+const email = (config.email as string) ?? 'bfmumo@gmail.com';
 ---
 
 <section class="now-footer">

--- a/frontend/src/components/home/NowFooter.astro
+++ b/frontend/src/components/home/NowFooter.astro
@@ -1,0 +1,222 @@
+---
+import { profileConfig } from '@/config';
+
+// "Esta semana" — actualizar manualmente o conectar a una API de notion/obsidian en el futuro
+const thisWeek = [
+  'Explorando NestJS guards y decoradores personalizados',
+  'Leyendo sobre sistemas distribuidos',
+  'Fotografiando en las calles del centro de Bogotá',
+];
+
+const email = 'bfmumo@gmail.com';
+---
+
+<section class="now-footer">
+  <div class="now-footer__inner">
+
+    <!-- Live clock Bogotá -->
+    <div class="now-footer__clock-block">
+      <p class="now-footer__location">
+        <span class="now-footer__dot" aria-hidden="true"></span>
+        Bogotá, Colombia · UTC−5
+      </p>
+      <time class="now-footer__clock" id="now-clock" datetime="" aria-live="off">
+        --:--
+      </time>
+    </div>
+
+    <!-- Esta semana -->
+    <div class="now-footer__week">
+      <p class="now-footer__section-label">Esta semana</p>
+      <ul class="now-footer__list" role="list">
+        {thisWeek.map((item) => (
+          <li class="now-footer__list-item">
+            <span class="now-footer__bullet" aria-hidden="true">→</span>
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+
+    <!-- Contact + socials -->
+    <div class="now-footer__contact">
+      <p class="now-footer__section-label">Contacto</p>
+      <a href={`mailto:${email}`} class="now-footer__email">{email}</a>
+
+      <div class="now-footer__socials">
+        {profileConfig.links.map((link) => (
+          <a
+            href={link.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="now-footer__social"
+            aria-label={link.name}
+          >
+            <span aria-hidden="true">↗</span>
+            {link.name}
+          </a>
+        ))}
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<style>
+  .now-footer {
+    width: 100%;
+    padding: 2.5rem 1.5rem;
+    background: var(--card-bg);
+    border-radius: var(--radius-large);
+    box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+    border-top: 3px solid #06b6d4;
+  }
+
+  .now-footer__inner {
+    max-width: 56rem;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  @media (min-width: 560px) { .now-footer__inner { grid-template-columns: auto 1fr auto; align-items: start; gap: 3rem; } }
+
+  /* ── Clock ── */
+  .now-footer__clock-block { display: flex; flex-direction: column; gap: 0.25rem; }
+
+  .now-footer__location {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--deep-text);
+    opacity: 0.55;
+    margin: 0;
+  }
+
+  .now-footer__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 9999px;
+    background: #22c55e;
+    box-shadow: 0 0 6px #22c55e;
+    flex-shrink: 0;
+    animation: dot-live 2.5s ease-in-out infinite;
+  }
+
+  .now-footer__clock {
+    font-family: ui-monospace, 'JetBrains Mono', monospace;
+    font-size: clamp(2rem, 5vw, 3rem);
+    font-weight: 700;
+    color: #06b6d4;
+    letter-spacing: -0.02em;
+    line-height: 1;
+  }
+
+  /* ── Esta semana ── */
+  .now-footer__section-label {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--deep-text);
+    opacity: 0.5;
+    margin: 0 0 0.6rem;
+  }
+
+  .now-footer__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  .now-footer__list-item {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 0.88rem;
+    color: var(--deep-text);
+    line-height: 1.5;
+  }
+
+  .now-footer__bullet {
+    color: #06b6d4;
+    font-weight: 700;
+    flex-shrink: 0;
+    font-size: 0.75rem;
+  }
+
+  /* ── Contact ── */
+  .now-footer__email {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--primary);
+    text-decoration: none;
+    margin-bottom: 0.85rem;
+    transition: color 0.2s;
+  }
+  .now-footer__email:hover { color: #06b6d4; text-decoration: underline; }
+  .now-footer__email:focus-visible { outline: 2px solid var(--primary); outline-offset: 4px; border-radius: 2px; }
+
+  .now-footer__socials {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .now-footer__social {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 9999px;
+    background: var(--btn-regular-bg);
+    color: var(--btn-content);
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.18s ease, transform 0.18s ease;
+  }
+  .now-footer__social:hover { background: var(--btn-regular-bg-hover); transform: translateY(-1px); }
+  .now-footer__social:focus-visible { outline: 2px solid var(--primary); outline-offset: 4px; }
+
+  @keyframes dot-live {
+    0%, 100% { opacity: 1; box-shadow: 0 0 6px #22c55e; }
+    50%       { opacity: 0.5; box-shadow: 0 0 2px #22c55e; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .now-footer__dot { animation: none; }
+  }
+</style>
+
+<script data-swup-reload-script>
+  function startClock() {
+    const el = document.getElementById('now-clock');
+    if (!el) return;
+
+    function tick() {
+      const now = new Date(
+        new Date().toLocaleString('en-US', { timeZone: 'America/Bogota' })
+      );
+      const hh = String(now.getHours()).padStart(2, '0');
+      const mm = String(now.getMinutes()).padStart(2, '0');
+      const ss = String(now.getSeconds()).padStart(2, '0');
+      el.textContent = `${hh}:${mm}:${ss}`;
+      el.setAttribute('datetime', now.toISOString());
+    }
+
+    tick();
+    setInterval(tick, 1000);
+  }
+
+  startClock();
+</script>

--- a/frontend/src/components/home/SeccionesGrid.astro
+++ b/frontend/src/components/home/SeccionesGrid.astro
@@ -5,7 +5,7 @@ interface Props {
 
 const { config = {} } = Astro.props;
 
-const title = (config.title as string) ?? 'Explora mi contenido';
+const title    = (config.title as string)    ?? 'Explora mi contenido';
 const subtitle = (config.subtitle as string) ?? 'Descubre mis proyectos, ideas y pasiones a través de estas secciones.';
 
 const defaultItems = [
@@ -13,30 +13,176 @@ const defaultItems = [
   { titulo: '🌟 Exploraciones artísticas', descripcion: 'Fotografía y momentos que inspiran.', enlace: '/gallery/' },
   { titulo: '📝 Resúmenes y opiniones', descripcion: 'Libros que leo y reflexiones sobre ellos.', enlace: '/blogs/' },
   { titulo: '📚 Guías y artículos', descripcion: 'Soluciones y optimización de procesos.', enlace: '/archive/' },
+  { titulo: '📖 Libros', descripcion: 'Los libros que estoy leyendo y mis notas sobre ellos.', enlace: '/books/' },
   { titulo: '💻 Portafolio', descripcion: 'Proyectos destacados de desarrollo de software.', enlace: 'https://portfolio.bfmu.dev' },
 ];
 
-const items = Array.isArray(config.items) && config.items.length > 0
-  ? (config.items as Array<{ titulo: string; descripcion: string; enlace: string }>)
-  : defaultItems;
+const items =
+  Array.isArray(config.items) && config.items.length > 0
+    ? (config.items as Array<{ titulo: string; descripcion: string; enlace: string }>)
+    : defaultItems;
 ---
 
-<section class="w-full py-16 bg-[var(--card-bg)] text-center rounded-[var(--radius-large)] shadow-md">
-    <div class="max-w-5xl mx-auto px-6">
-        <h2 class="text-3xl font-bold text-[var(--primary)] dark:text-[var(--title-active)]">{title}</h2>
-        <p class="text-lg text-[var(--deep-text)] dark:text-white mt-4">{subtitle}</p>
-    </div>
+<section class="bento" id="work">
+  <div class="bento__header">
+    <h2 class="bento__title">{title}</h2>
+    <p class="bento__subtitle">{subtitle}</p>
+  </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6 mt-8 max-w-5xl mx-auto px-6">
-        {items.map((seccion, i) => (
-            <a
-                href={seccion.enlace}
-                class="seccion-card p-6 bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] active:bg-[var(--btn-regular-bg-active)] text-[var(--btn-content)] rounded-lg text-lg font-semibold transition-all duration-300 shadow-md hover:shadow-xl hover:scale-[1.02] border-2 border-transparent hover:border-[var(--primary)] block text-center"
-                style={`animation-delay: ${i * 80}ms`}
-            >
-                <h3 class="text-xl font-semibold text-[var(--primary)] dark:text-[var(--title-active)]">{seccion.titulo}</h3>
-                <p class="text-[var(--deep-text)] dark:text-white mt-2">{seccion.descripcion}</p>
-            </a>
-        ))}
-    </div>
+  <div class="bento__grid">
+    {items.map((item, i) => {
+      const isExternal = item.enlace.startsWith('http');
+      return (
+        <a
+          href={item.enlace}
+          class="bento-card"
+          style={`--delay: ${i * 60}ms`}
+          target={isExternal ? '_blank' : undefined}
+          rel={isExternal ? 'noopener noreferrer' : undefined}
+          aria-label={item.titulo}
+        >
+          <!-- Animated cyan accent bar -->
+          <span class="bento-card__accent" aria-hidden="true"></span>
+
+          <div class="bento-card__body">
+            <h3 class="bento-card__name">{item.titulo}</h3>
+            <p class="bento-card__desc">{item.descripcion}</p>
+          </div>
+
+          <div class="bento-card__footer">
+            <span class="bento-card__arrow" aria-hidden="true">→</span>
+          </div>
+        </a>
+      );
+    })}
+  </div>
 </section>
+
+<style>
+  .bento {
+    width: 100%;
+    padding: 3rem 1.5rem;
+    background: var(--card-bg);
+    border-radius: var(--radius-large);
+    box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+  }
+
+  .bento__header {
+    max-width: 44rem;
+    margin: 0 auto 2.25rem;
+    text-align: center;
+  }
+
+  .bento__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--primary);
+    margin: 0 0 0.5rem;
+  }
+
+  .bento__subtitle {
+    font-size: 1rem;
+    color: var(--deep-text);
+    margin: 0;
+    opacity: 0.8;
+    line-height: 1.6;
+  }
+
+  .bento__grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    max-width: 56rem;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 480px) { .bento__grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (min-width: 720px) { .bento__grid { grid-template-columns: repeat(3, 1fr); } }
+
+  /* ── Card ── */
+  .bento-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    padding: 1.35rem 1.25rem 1rem;
+    border-radius: 0.875rem;
+    background: var(--btn-regular-bg);
+    border: 1px solid transparent;
+    text-decoration: none;
+    overflow: hidden;
+    transition: background 0.22s ease, border-color 0.22s ease,
+                transform 0.22s cubic-bezier(0.34,1.56,0.64,1),
+                box-shadow 0.22s ease;
+    animation: card-in 0.45s ease both;
+    animation-delay: var(--delay, 0ms);
+  }
+  .bento-card:hover {
+    background: var(--btn-regular-bg-hover);
+    border-color: var(--primary);
+    transform: translateY(-3px);
+    box-shadow: 0 8px 24px -8px rgb(0 0 0 / 0.14);
+  }
+  .bento-card:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  /* Animated left accent bar */
+  .bento-card__accent {
+    position: absolute;
+    top: 12%;
+    left: 0;
+    width: 3px;
+    height: 0%;
+    background: #06b6d4;
+    border-radius: 0 2px 2px 0;
+    transition: height 0.3s cubic-bezier(0.34,1.56,0.64,1);
+  }
+  .bento-card:hover .bento-card__accent { height: 76%; }
+
+  .bento-card__body { flex: 1; padding-left: 0.25rem; }
+
+  .bento-card__name {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--primary);
+    margin: 0 0 0.4rem;
+    line-height: 1.35;
+  }
+
+  .bento-card__desc {
+    font-size: 0.83rem;
+    color: var(--deep-text);
+    margin: 0;
+    line-height: 1.55;
+    opacity: 0.85;
+  }
+
+  .bento-card__footer {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+  }
+
+  .bento-card__arrow {
+    font-size: 0.9rem;
+    color: var(--primary);
+    opacity: 0.6;
+    transition: transform 0.2s ease, opacity 0.2s;
+  }
+  .bento-card:hover .bento-card__arrow {
+    transform: translateX(4px);
+    opacity: 1;
+  }
+
+  @keyframes card-in {
+    from { opacity: 0; transform: translateY(14px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bento-card { animation: none; transition: none; }
+    .bento-card__accent { transition: none; }
+    .bento-card:hover { transform: none; }
+  }
+</style>

--- a/frontend/src/components/home/SpotifyChip.tsx
+++ b/frontend/src/components/home/SpotifyChip.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface Track {
+  name: string;
+  artist: string;
+  album: string;
+  coverUrl: string | null;
+  spotifyUrl: string | null;
+}
+
+interface NowPlayingData {
+  playing: boolean;
+  track: Track | null;
+}
+
+function getApiUrl(): string {
+  const base = (import.meta as any).env?.PUBLIC_BACKEND_URL || 'http://localhost:3000/';
+  return `${base.replace(/\/$/, '')}/api/spotify/now-playing`;
+}
+
+/* RAF-based bar visualizer — heights updated via refs (zero re-renders) */
+function VisualizerBars({ playing }: { playing: boolean }) {
+  const barRefs = useRef<(HTMLSpanElement | null)[]>([]);
+  const heightsRef = useRef<number[]>([0.25, 0.55, 0.85, 0.4, 0.7, 0.35]);
+  const rafRef = useRef<number>(0);
+
+  const STATIC_H = [0.3, 0.6, 0.95, 0.5, 0.75, 0.4];
+
+  useEffect(() => {
+    if (!playing) {
+      cancelAnimationFrame(rafRef.current);
+      barRefs.current.forEach((bar, i) => {
+        if (bar) bar.style.height = `${STATIC_H[i] * 20}px`;
+      });
+      return;
+    }
+
+    function animate() {
+      heightsRef.current = heightsRef.current.map((h) => {
+        const next = h + (Math.random() - 0.5) * 0.32;
+        return Math.max(0.12, Math.min(1, next));
+      });
+      barRefs.current.forEach((bar, i) => {
+        if (bar) bar.style.height = `${heightsRef.current[i] * 20}px`;
+      });
+      rafRef.current = requestAnimationFrame(animate);
+    }
+
+    rafRef.current = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [playing]);
+
+  return (
+    <span
+      aria-hidden="true"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'flex-end',
+        gap: '2px',
+        height: '20px',
+        flexShrink: 0,
+      }}
+    >
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <span
+          key={i}
+          ref={(el) => { barRefs.current[i] = el; }}
+          style={{
+            display: 'block',
+            width: '3px',
+            height: `${STATIC_H[i] * 20}px`,
+            borderRadius: '2px',
+            background: playing ? '#06b6d4' : 'currentColor',
+            opacity: playing ? 1 : 0.35,
+            transition: playing ? 'none' : 'height 0.3s ease',
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default function SpotifyChip() {
+  const [data, setData] = useState<NowPlayingData | null>(null);
+
+  useEffect(() => {
+    const url = getApiUrl();
+    let cancelled = false;
+
+    async function fetchData() {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) return;
+        const json: NowPlayingData = await res.json();
+        if (!cancelled) setData(json);
+      } catch {}
+    }
+
+    fetchData();
+    const id = setInterval(fetchData, 30_000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
+
+  if (!data?.track) return null;
+
+  const { track, playing } = data;
+
+  return (
+    <a
+      href={track.spotifyUrl ?? '/music/'}
+      target={track.spotifyUrl ? '_blank' : undefined}
+      rel={track.spotifyUrl ? 'noopener noreferrer' : undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.65rem',
+        padding: '0.6rem 0.85rem',
+        borderRadius: '0.75rem',
+        background: 'var(--card-bg)',
+        border: '1px solid var(--line-divider)',
+        textDecoration: 'none',
+        transition: 'border-color 0.2s, transform 0.2s, box-shadow 0.2s',
+        flexShrink: 0,
+      }}
+      onMouseEnter={(e) => {
+        const el = e.currentTarget as HTMLElement;
+        el.style.borderColor = '#06b6d4';
+        el.style.transform = 'translateY(-2px)';
+        el.style.boxShadow = '0 4px 16px -4px rgba(6,182,212,0.3)';
+      }}
+      onMouseLeave={(e) => {
+        const el = e.currentTarget as HTMLElement;
+        el.style.borderColor = '';
+        el.style.transform = '';
+        el.style.boxShadow = '';
+      }}
+    >
+      {/* Cover image */}
+      {track.coverUrl ? (
+        <img
+          src={track.coverUrl}
+          alt=""
+          style={{ width: '2.25rem', height: '2.25rem', borderRadius: '0.4rem', objectFit: 'cover', flexShrink: 0 }}
+        />
+      ) : (
+        <span style={{ fontSize: '1.4rem', flexShrink: 0 }}>🎵</span>
+      )}
+
+      {/* Text */}
+      <span style={{ minWidth: 0, flex: 1 }}>
+        <span
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.3rem',
+            fontSize: '0.65rem',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--deep-text)',
+            opacity: 0.6,
+          }}
+        >
+          {playing && (
+            <span
+              style={{
+                display: 'inline-block',
+                width: '6px',
+                height: '6px',
+                borderRadius: '9999px',
+                background: '#22c55e',
+                boxShadow: '0 0 5px #22c55e',
+              }}
+            />
+          )}
+          {playing ? 'Escuchando ahora' : 'Última canción'}
+        </span>
+        <span
+          style={{
+            display: 'block',
+            fontSize: '0.82rem',
+            fontWeight: 600,
+            color: 'var(--primary)',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            lineHeight: 1.3,
+          }}
+        >
+          {track.name}
+        </span>
+        <span
+          style={{
+            display: 'block',
+            fontSize: '0.72rem',
+            color: 'var(--deep-text)',
+            opacity: 0.7,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {track.artist}
+        </span>
+      </span>
+
+      {/* Visualizer */}
+      <VisualizerBars playing={playing} />
+    </a>
+  );
+}

--- a/frontend/src/components/home/UltimosPosts.astro
+++ b/frontend/src/components/home/UltimosPosts.astro
@@ -9,58 +9,297 @@ interface Props {
 
 const { config = {} } = Astro.props;
 
-const title = (config.title as string) ?? 'Últimos artículos';
-const subtitle = (config.subtitle as string) ?? 'Explora las publicaciones más recientes de mi blog.';
-const limit = typeof config.limit === 'number' ? config.limit : 3;
+const title   = (config.title as string)   ?? 'Últimos artículos';
+const subtitle= (config.subtitle as string)?? 'Explora las publicaciones más recientes.';
+const limit   = typeof config.limit === 'number' ? config.limit : 4;
 const ctaText = (config.ctaText as string) ?? 'Ver todos los artículos';
 const ctaHref = (config.ctaHref as string) ?? '/blogs/';
 
-let ultimosPosts: Array<{ slug: string; title: string; description?: string; image?: string; published: string }> = [];
+let posts: Array<{
+  slug: string;
+  title: string;
+  description?: string;
+  image?: string;
+  published: string;
+  readingTime?: number;
+  tags?: string[];
+}> = [];
+
 try {
-  ultimosPosts = await fetchRecentPosts(limit);
+  posts = await fetchRecentPosts(limit);
 } catch (e) {
-  console.error('[UltimosPosts] Error al obtener posts recientes:', e);
+  console.error('[UltimosPosts]', e);
 }
 
 const now = Date.now();
-const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
-function isNew(published: string): boolean {
-  const t = new Date(published).getTime();
-  return now - t <= sevenDaysMs;
-}
+function isNew(published: string) { return now - new Date(published).getTime() <= 7 * 86400_000; }
+
+function pad(n: number) { return String(n).padStart(2, '0'); }
 ---
 
-<section class="w-full py-16 bg-[var(--card-bg)] text-center rounded-[var(--radius-large)] shadow-md">
-    <div class="max-w-5xl mx-auto px-6">
-        <h2 class="text-3xl font-bold text-[var(--primary)] dark:text-[var(--title-active)]">
-            {title}
-        </h2>
-        <p class="text-lg text-[var(--deep-text)] dark:text-white mt-4">{subtitle}</p>
-    </div>
+<section class="articles">
+  <div class="articles__header">
+    <h2 class="articles__title">{title}</h2>
+    <p class="articles__subtitle">{subtitle}</p>
+  </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8 max-w-5xl mx-auto px-6">
-        {ultimosPosts.length > 0 ? ultimosPosts.map((entry) => (
-            <a href={getPostUrlBySlug(entry.slug)} class="relative group overflow-hidden rounded-[var(--radius-large)] shadow-md block bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
-                {entry.image && (
-                    <div class="overflow-hidden">
-                        <img src={entry.image.startsWith('/uploads/') ? getOptimizedImageUrl(entry.image, 600) : entry.image} alt={entry.title} class="w-full h-48 object-cover transition duration-300 group-hover:scale-105" />
-                    </div>
+  {posts.length > 0 ? (
+    <ol class="articles__list" role="list">
+      {posts.map((post, i) => (
+        <li class="articles__item">
+          <a href={getPostUrlBySlug(post.slug)} class="articles__link">
+            <!-- Number -->
+            <span class="articles__num" aria-hidden="true">{pad(i + 1)}</span>
+
+            <!-- Main content -->
+            <span class="articles__content">
+              <span class="articles__meta">
+                {post.tags?.[0] && (
+                  <span class="articles__tag">{post.tags[0]}</span>
                 )}
-                {isNew(entry.published) && (
-                    <span class="absolute top-3 right-3 z-10 rounded-full bg-[var(--primary)] px-2.5 py-0.5 text-xs font-medium text-white">Nuevo</span>
+                <span class="articles__date">
+                  {new Date(post.published).toLocaleDateString('es', { day: 'numeric', month: 'short', year: 'numeric' })}
+                </span>
+                {post.readingTime && (
+                  <span class="articles__read">{post.readingTime} min</span>
                 )}
-                <div class="p-6 text-left">
-                    <h3 class="text-xl font-semibold text-[var(--primary)] dark:text-[var(--title-active)]">{entry.title}</h3>
-                    <p class="text-[var(--deep-text)] dark:text-white mt-2 line-clamp-3">{entry.description}</p>
-                    <span class="text-sm text-[var(--deep-text)] dark:text-gray-300 mt-4 block">{new Date(entry.published).toLocaleDateString()}</span>
-                </div>
-                <div class="absolute inset-0 bg-black/10 opacity-0 group-hover:opacity-10 transition pointer-events-none"></div>
-            </a>
-        )) : (
-            <p class="col-span-full text-[var(--deep-text)] dark:text-gray-400">No hay artículos recientes o la API no está disponible.</p>
-        )}
-    </div>
-    <div class="mt-8 text-center">
-        <a href={ctaHref} class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--btn-regular-bg)] hover:bg-[var(--btn-regular-bg-hover)] text-[var(--btn-content)] font-medium transition">{ctaText}</a>
-    </div>
+                {isNew(post.published) && (
+                  <span class="articles__new">nuevo</span>
+                )}
+              </span>
+              <span class="articles__post-title">{post.title}</span>
+              {post.description && (
+                <span class="articles__desc">{post.description}</span>
+              )}
+            </span>
+
+            {/* Thumbnail */}
+            {post.image && (
+              <img
+                src={post.image.startsWith('/uploads/') ? getOptimizedImageUrl(post.image, 120) : post.image}
+                alt=""
+                class="articles__thumb"
+                loading="lazy"
+                width="64"
+                height="64"
+              />
+            )}
+          </a>
+        </li>
+      ))}
+    </ol>
+  ) : (
+    <p class="articles__empty">No hay artículos recientes disponibles.</p>
+  )}
+
+  <div class="articles__footer">
+    <a href={ctaHref} class="articles__cta">
+      {ctaText}
+      <span aria-hidden="true">→</span>
+    </a>
+  </div>
 </section>
+
+<style>
+  .articles {
+    width: 100%;
+    padding: 3rem 1.5rem;
+    background: var(--card-bg);
+    border-radius: var(--radius-large);
+    box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+  }
+
+  .articles__header {
+    margin-bottom: 2rem;
+  }
+
+  .articles__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--primary);
+    margin: 0 0 0.4rem;
+  }
+
+  .articles__subtitle {
+    font-size: 0.95rem;
+    color: var(--deep-text);
+    margin: 0;
+    opacity: 0.75;
+  }
+
+  /* ── List ── */
+  .articles__list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .articles__item {
+    border-bottom: 1px solid var(--line-divider);
+  }
+  .articles__item:first-child {
+    border-top: 1px solid var(--line-divider);
+  }
+
+  .articles__link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 0.5rem;
+    text-decoration: none;
+    border-radius: 0.5rem;
+    margin: 0 -0.5rem;
+    transition: background 0.18s ease, transform 0.18s ease;
+  }
+  .articles__link:hover {
+    background: var(--btn-regular-bg);
+    transform: translateX(6px);
+  }
+  .articles__link:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+  }
+
+  /* Number */
+  .articles__num {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--primary);
+    opacity: 0.25;
+    font-variant-numeric: tabular-nums;
+    font-family: ui-monospace, monospace;
+    flex-shrink: 0;
+    width: 2.5rem;
+    text-align: right;
+    transition: opacity 0.18s ease;
+  }
+  .articles__link:hover .articles__num { opacity: 0.7; }
+
+  /* Content */
+  .articles__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .articles__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.7rem;
+  }
+
+  .articles__tag {
+    padding: 0.15rem 0.55rem;
+    border-radius: 9999px;
+    background: var(--btn-regular-bg);
+    color: var(--btn-content);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.62rem;
+  }
+
+  .articles__date,
+  .articles__read {
+    color: var(--deep-text);
+    opacity: 0.6;
+  }
+
+  .articles__new {
+    padding: 0.1rem 0.45rem;
+    border-radius: 9999px;
+    background: #06b6d4;
+    color: white;
+    font-weight: 700;
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .articles__post-title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--deep-text);
+    line-height: 1.4;
+    transition: color 0.18s ease;
+    /* Growing underline */
+    display: inline;
+    background-image: linear-gradient(currentColor, currentColor);
+    background-size: 0% 1px;
+    background-position: left bottom;
+    background-repeat: no-repeat;
+    transition: background-size 0.25s ease, color 0.18s ease;
+  }
+  .articles__link:hover .articles__post-title {
+    color: var(--primary);
+    background-size: 100% 1px;
+  }
+
+  .articles__desc {
+    font-size: 0.8rem;
+    color: var(--deep-text);
+    opacity: 0.65;
+    line-height: 1.5;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+  }
+
+  /* Thumbnail */
+  .articles__thumb {
+    width: 3.75rem;
+    height: 3.75rem;
+    border-radius: 0.5rem;
+    object-fit: cover;
+    flex-shrink: 0;
+    opacity: 0.85;
+    transition: opacity 0.18s ease;
+  }
+  .articles__link:hover .articles__thumb { opacity: 1; }
+
+  .articles__empty {
+    color: var(--deep-text);
+    opacity: 0.6;
+    font-size: 0.9rem;
+    padding: 1rem 0;
+  }
+
+  /* CTA */
+  .articles__footer { margin-top: 0.5rem; }
+
+  .articles__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1.4rem;
+    border-radius: 9999px;
+    background: var(--btn-regular-bg);
+    color: var(--btn-content);
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-decoration: none;
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+  .articles__cta:hover {
+    background: var(--btn-regular-bg-hover);
+    transform: translateY(-1px);
+  }
+  .articles__cta:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 4px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .articles__link { transition: none; }
+    .articles__link:hover { transform: none; }
+    .articles__post-title { background-image: none; transition: none; }
+  }
+</style>

--- a/frontend/src/components/home/componentRegistry.ts
+++ b/frontend/src/components/home/componentRegistry.ts
@@ -32,6 +32,7 @@ export const DEFAULT_HOMEPAGE_SECTIONS: HomepageSection[] = [
       imageUrls: [] as string[],
       carouselIntervalSeconds: 5.5,
       heightVh: 70,
+      eyebrow: 'BRYAN F. MUÑOZ M. · BOGOTÁ',
       title: 'Desarrollo, Fotografía y Reflexión',
       subtitle:
         'Desarrollo soluciones. Capturo momentos. Reflexiono sobre historias. Aquí es donde todo converge.',
@@ -137,6 +138,9 @@ export const DEFAULT_HOMEPAGE_SECTIONS: HomepageSection[] = [
     id: 'now-footer',
     enabled: true,
     order: 7,
-    config: {},
+    config: {
+      email: 'bfmumo@gmail.com',
+      thisWeek: [] as string[],
+    },
   },
 ];

--- a/frontend/src/components/home/componentRegistry.ts
+++ b/frontend/src/components/home/componentRegistry.ts
@@ -10,6 +10,7 @@ export const HOME_SECTION_IDS = [
   'secciones',
   'gallery-preview',
   'ultimos-posts',
+  'now-footer',
 ] as const;
 
 export type HomeSectionId = (typeof HOME_SECTION_IDS)[number];
@@ -127,9 +128,15 @@ export const DEFAULT_HOMEPAGE_SECTIONS: HomepageSection[] = [
     config: {
       title: 'Últimos artículos',
       subtitle: 'Explora las publicaciones más recientes de mi blog.',
-      limit: 3,
+      limit: 4,
       ctaText: 'Ver todos los artículos',
       ctaHref: '/blogs/',
     },
+  },
+  {
+    id: 'now-footer',
+    enabled: true,
+    order: 7,
+    config: {},
   },
 ];

--- a/frontend/src/lib/hero-animations.ts
+++ b/frontend/src/lib/hero-animations.ts
@@ -1,0 +1,89 @@
+const reduced = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+export function initWordReveal(el: HTMLElement): void {
+  const text = (el.dataset.text ?? el.textContent ?? '').trim();
+  const words = text.split(/\s+/);
+
+  el.innerHTML =
+    `<span class="sr-only">${text}</span>` +
+    words
+      .map((w, i) => `<span class="hw" aria-hidden="true" style="--wi:${i}">${w}</span>`)
+      .join(' ');
+
+  if (reduced()) {
+    el.querySelectorAll<HTMLElement>('.hw').forEach((s) => s.classList.add('hw--v'));
+    return;
+  }
+
+  words.forEach((_, i) => {
+    setTimeout(
+      () => (el.querySelectorAll('.hw')[i] as HTMLElement | null)?.classList.add('hw--v'),
+      350 + i * 110,
+    );
+  });
+}
+
+export function initSubtitleReveal(el: HTMLElement): void {
+  const delay = reduced() ? 0 : 950;
+  setTimeout(() => el.classList.add('hero__subtitle--v'), delay);
+}
+
+export function initParallax(bg: HTMLElement): void {
+  if (reduced()) return;
+  let mx = 0, my = 0, sy = 0;
+
+  const update = () => {
+    bg.style.transform = `translate(${mx * 18}px, ${my * 10 + sy * 0.1}px) scale(1.12)`;
+  };
+
+  document.addEventListener('mousemove', (e) => {
+    mx = e.clientX / window.innerWidth - 0.5;
+    my = e.clientY / window.innerHeight - 0.5;
+    requestAnimationFrame(update);
+  }, { passive: true });
+
+  window.addEventListener('scroll', () => {
+    sy = window.scrollY;
+    requestAnimationFrame(update);
+  }, { passive: true });
+}
+
+export function initMagnetic(btn: HTMLElement): void {
+  if (reduced() || window.matchMedia('(hover: none)').matches) return;
+  const R = 115, S = 0.38;
+
+  document.addEventListener('mousemove', (e) => {
+    const r = btn.getBoundingClientRect();
+    const dx = e.clientX - (r.left + r.width / 2);
+    const dy = e.clientY - (r.top + r.height / 2);
+    const d = Math.hypot(dx, dy);
+    btn.style.transform =
+      d < R ? `translate(${dx * S * (1 - d / R)}px, ${dy * S * (1 - d / R)}px)` : '';
+  }, { passive: true });
+}
+
+export function initScrollCue(cue: HTMLElement): void {
+  window.addEventListener('scroll', () => {
+    const gone = window.scrollY > 50;
+    cue.style.opacity = gone ? '0' : '1';
+    cue.style.pointerEvents = gone ? 'none' : '';
+  }, { passive: true });
+}
+
+export function initHeroAnimations(): void {
+  if (typeof window === 'undefined') return;
+
+  const title    = document.querySelector<HTMLElement>('[data-word-reveal]');
+  const subtitle = document.querySelector<HTMLElement>('[data-subtitle-reveal]');
+  const bg       = document.querySelector<HTMLElement>('[data-parallax-bg]');
+  const cta      = document.querySelector<HTMLElement>('[data-magnetic]');
+  const cue      = document.querySelector<HTMLElement>('[data-scroll-cue]');
+
+  if (title)    initWordReveal(title);
+  if (subtitle) initSubtitleReveal(subtitle);
+  if (bg)       initParallax(bg);
+  if (cta)      initMagnetic(cta);
+  if (cue)      initScrollCue(cue);
+}


### PR DESCRIPTION
## Resumen

Rediseño completo de la home con foco en interactividad real (no CSS keyframes genéricos).

### Hero
- Eyebrow pill con dot pulsante y ubicación
- Título con word-reveal staggerado (blur→focus)
- Parallax doble: mousemove + scroll
- Botón CTA magnético (sigue el cursor dentro de 115px)
- Scroll-cue bouncing que desaparece al scrollear

### AboutCard
- Stats (artículos / álbumes / libros) con count-up animado al viewport
- Avatar con anillo rotante conic-gradient
- Foto B&W → color en hover
- Cursor `_` parpadeante

### ActivityStrip (SpotifyChip)
- `SpotifyChip.tsx`: visualizador de barras RAF (random-walk por frame, cero re-renders)
- Book chip con barra de progreso vertical
- Album chip con hover coloreado

### ExploreBento
- Accent bar cyan 3px animado al hover
- Hover: lift + border primary

### GalleryTeaser
- Fotos B&W → color + scale al hover
- Caption que sube al hover

### ArticlesTeaser
- Lista numerada (01, 02, 03...)
- Hover: slide-right + subrayado que crece

### NowFooter (nuevo)
- Reloj live HH:MM:SS Bogotá (vanilla JS)
- "Esta semana" con bullets cyan
- Email + socials

## Test plan
- [ ] Hero: verificar parallax en desktop, word-reveal, botón magnético
- [ ] AboutCard: stats cuentan al entrar en viewport
- [ ] SpotifyChip: barras animan cuando hay canción activa en Spotify
- [ ] Galería: fotos arrancan en B&W, pasan a color en hover
- [ ] NowFooter: reloj actualiza cada segundo con hora de Bogotá
- [ ] Mobile: todos los componentes colapsan a 1 columna correctamente
- [ ] Dark mode: todos los componentes usan las CSS variables correctas
- [ ] `prefers-reduced-motion`: animaciones desactivadas

🤖 Generated with [Claude Code](https://claude.com/claude-code)