### PR TITLE
fix(homepage): duplicado ActivityStrip, galería, bordes cyan y SSR backend URL

### DIFF
--- a/backend/src/homepage/homepage.service.ts
+++ b/backend/src/homepage/homepage.service.ts
@@ -22,7 +22,7 @@ const DEFAULT_SECTIONS = [
   },
   {
     id: 'now-listening',
-    enabled: true,
+    enabled: false,
     order: 1,
     config: {},
   },

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -73,6 +73,7 @@ services:
     environment:
       - PUBLIC_WEB_SITE_URL=${PUBLIC_WEB_SITE_URL}
       - PUBLIC_BACKEND_URL=${PUBLIC_BACKEND_URL}
+      - PUBLIC_BACKEND_URL_SSR=http://backend:3000
       - PUBLIC_GRAFANA_URL=${GRAFANA_PUBLIC_URL:-https://grafana.bfmu.dev/}
     networks:
       - internal

--- a/frontend/src/components/home/GalleryPreview.astro
+++ b/frontend/src/components/home/GalleryPreview.astro
@@ -22,7 +22,8 @@ try {
   if (albumSlugsFilter.length > 0) {
     albums = albums.filter((a) => albumSlugsFilter.includes(a.slug));
   }
-  albums = albums.slice(0, 2);
+  // Solo mostrar álbumes con cover image para evitar placeholders vacíos
+  albums = albums.filter((a) => a.coverImage).slice(0, 2);
 } catch (_) {}
 ---
 
@@ -34,32 +35,22 @@ try {
     </a>
   </div>
 
-  <div class="gallery-teaser__grid">
-    {albums.length > 0 ? albums.map((album) => {
-      const cover = album.coverImage ? getOptimizedImageUrl(album.coverImage, 800) : null;
-      return (
-        <a href={`/gallery/${album.slug}/`} class="gallery-photo" aria-label={album.title}>
-          {cover ? (
+  {albums.length > 0 && (
+    <div class="gallery-teaser__grid">
+      {albums.map((album) => {
+        const cover = getOptimizedImageUrl(album.coverImage!, 800);
+        return (
+          <a href={`/gallery/${album.slug}/`} class="gallery-photo" aria-label={album.title}>
             <img src={cover} alt={album.title} class="gallery-photo__img" loading="lazy" />
-          ) : (
-            <div class="gallery-photo__placeholder" aria-hidden="true">📷</div>
-          )}
-          <div class="gallery-photo__caption">
-            <span>{album.title}</span>
-            <span class="gallery-photo__arrow" aria-hidden="true">→</span>
-          </div>
-        </a>
-      );
-    }) : (
-      <a href={ctaHref} class="gallery-photo gallery-photo--cta">
-        <div class="gallery-photo__placeholder" aria-hidden="true">📷</div>
-        <div class="gallery-photo__caption">
-          <span>Ver galería</span>
-          <span class="gallery-photo__arrow" aria-hidden="true">→</span>
-        </div>
-      </a>
-    )}
-  </div>
+            <div class="gallery-photo__caption">
+              <span>{album.title}</span>
+              <span class="gallery-photo__arrow" aria-hidden="true">→</span>
+            </div>
+          </a>
+        );
+      })}
+    </div>
+  )}
 </section>
 
 <style>
@@ -69,6 +60,7 @@ try {
     background: var(--card-bg);
     border-radius: var(--radius-large);
     box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+    border-top: 3px solid #06b6d4;
   }
 
   .gallery-teaser__header {

--- a/frontend/src/components/home/IntroPersonal.astro
+++ b/frontend/src/components/home/IntroPersonal.astro
@@ -101,6 +101,7 @@ const isExternal = ctaHref.startsWith('http');
     background: var(--card-bg);
     border-radius: var(--radius-large);
     box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+    border-top: 3px solid #06b6d4;
   }
 
   .about-card__inner {

--- a/frontend/src/components/home/NowFooter.astro
+++ b/frontend/src/components/home/NowFooter.astro
@@ -82,14 +82,21 @@ const email = (config.email as string) ?? 'bfmumo@gmail.com';
   }
 
   .now-footer__inner {
-    max-width: 56rem;
+    max-width: 48rem;
     margin: 0 auto;
     display: grid;
     grid-template-columns: 1fr;
     gap: 2rem;
   }
 
-  @media (min-width: 560px) { .now-footer__inner { grid-template-columns: auto 1fr auto; align-items: start; gap: 3rem; } }
+  @media (min-width: 560px) {
+    .now-footer__inner {
+      grid-template-columns: auto 1fr auto;
+      align-items: start;
+      gap: 2.5rem;
+      justify-items: start;
+    }
+  }
 
   /* ── Clock ── */
   .now-footer__clock-block { display: flex; flex-direction: column; gap: 0.25rem; }

--- a/frontend/src/components/home/SeccionesGrid.astro
+++ b/frontend/src/components/home/SeccionesGrid.astro
@@ -65,6 +65,7 @@ const items =
     background: var(--card-bg);
     border-radius: var(--radius-large);
     box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+    border-top: 3px solid #06b6d4;
   }
 
   .bento__header {

--- a/frontend/src/components/home/UltimosPosts.astro
+++ b/frontend/src/components/home/UltimosPosts.astro
@@ -107,6 +107,7 @@ function pad(n: number) { return String(n).padStart(2, '0'); }
     background: var(--card-bg);
     border-radius: var(--radius-large);
     box-shadow: 0 2px 16px -4px rgb(0 0 0 / 0.07);
+    border-top: 3px solid #06b6d4;
   }
 
   .articles__header {

--- a/frontend/src/components/home/componentRegistry.ts
+++ b/frontend/src/components/home/componentRegistry.ts
@@ -42,7 +42,7 @@ export const DEFAULT_HOMEPAGE_SECTIONS: HomepageSection[] = [
   },
   {
     id: 'now-listening',
-    enabled: true,
+    enabled: false,
     order: 1,
     config: {},
   },


### PR DESCRIPTION
## Fixes

**Actividad reciente duplicada**
- Deshabilita `now-listening` en los defaults (frontend + backend) — `actividad-reciente` lo reemplaza

**Galería muestra placeholder vacío**
- Filtra solo álbumes con `coverImage` antes de slice(0,2)
- Si no hay ninguno, no muestra la grid (evita slots vacíos)

**Border-top cyan en todas las cards**
- Agrega `border-top: 3px solid #06b6d4` a AboutCard, ExploreBento, GalleryTeaser y ArticlesTeaser para consistencia con NowFooter

**NowFooter centrado**
- Reduce `max-width` a 48rem y ajusta el grid de 3 columnas

**Stats AboutCard en 0 (fix SSR)**
- Agrega `PUBLIC_BACKEND_URL_SSR=http://backend:3000` al `docker-compose.prod.yml`
- El SSR del frontend ahora llama al backend internamente (red Docker) en vez de pasar por internet → nginx → backend

## Test plan
- [ ] Solo aparece una sección de actividad reciente
- [ ] Galería muestra solo fotos con cover (sin placeholder vacío)
- [ ] Todas las cards tienen border-top cyan
- [ ] Stats de AboutCard muestran números reales tras redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)