### PR TITLE
fix(homepage): player interno, pause bug y stats en 0

### DIFF
--- a/frontend/src/components/home/IntroPersonal.astro
+++ b/frontend/src/components/home/IntroPersonal.astro
@@ -286,6 +286,20 @@ const isExternal = ctaHref.startsWith('http');
     })(performance.now());
   }
 
+  async function fetchStatCounts() {
+    const base = (import.meta.env.PUBLIC_BACKEND_URL as string | undefined)?.replace(/\/$/, '') ?? 'http://localhost:3000';
+    const [postsRes, albumsRes, booksRes] = await Promise.allSettled([
+      fetch(`${base}/api/blog?limit=1&page=1&draft=false`).then(r => r.ok ? r.json() : null),
+      fetch(`${base}/api/gallery/albums`).then(r => r.ok ? r.json() : null),
+      fetch(`${base}/api/books`).then(r => r.ok ? r.json() : null),
+    ]);
+    return {
+      posts:  postsRes.status  === 'fulfilled' ? (postsRes.value?.pagination?.total  ?? null) : null,
+      albums: albumsRes.status === 'fulfilled' ? (albumsRes.value?.pagination?.total ?? null) : null,
+      books:  booksRes.status  === 'fulfilled' && Array.isArray(booksRes.value) ? booksRes.value.length : null,
+    };
+  }
+
   function initCountStats() {
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const root = document.querySelector<HTMLElement>('[data-stats-root]');
@@ -293,8 +307,11 @@ const isExternal = ctaHref.startsWith('http');
 
     const stats = root.querySelectorAll<HTMLElement>('[data-count]');
 
-    const obs = new IntersectionObserver((entries) => {
-      if (!entries[0].isIntersecting) return;
+    let intersected = false;
+    let fetchDone = false;
+
+    function runAnimation() {
+      if (!intersected || !fetchDone) return;
       stats.forEach((stat) => {
         const target = parseInt(stat.dataset.count ?? '0', 10);
         const num = stat.querySelector<HTMLElement>('[data-stat-num]');
@@ -302,7 +319,27 @@ const isExternal = ctaHref.startsWith('http');
         if (reduced) { num.textContent = String(target); return; }
         countUp(num, target);
       });
+    }
+
+    // Fetch client-side para corregir ceros cuando el SSR no alcanzó el backend
+    fetchStatCounts().then((counts) => {
+      stats.forEach((stat) => {
+        const label = stat.querySelector<HTMLElement>('[data-stat-label]')?.textContent?.trim()
+          ?? stat.querySelector<HTMLElement>('.about-card__stat-label')?.textContent?.trim()
+          ?? '';
+        if (label.includes('artículos') && counts.posts   !== null) stat.dataset.count = String(counts.posts);
+        if (label.includes('álbum')     && counts.albums  !== null) stat.dataset.count = String(counts.albums);
+        if (label.includes('libro')     && counts.books   !== null) stat.dataset.count = String(counts.books);
+      });
+      fetchDone = true;
+      runAnimation();
+    }).catch(() => { fetchDone = true; runAnimation(); });
+
+    const obs = new IntersectionObserver((entries) => {
+      if (!entries[0].isIntersecting) return;
       obs.disconnect();
+      intersected = true;
+      runAnimation();
     }, { threshold: 0.3 });
 
     obs.observe(root);

--- a/frontend/src/components/home/SpotifyChip.tsx
+++ b/frontend/src/components/home/SpotifyChip.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { usePlayerStore } from '../music/playerStore';
 
 interface Track {
   name: string;
@@ -16,6 +17,10 @@ interface NowPlayingData {
 function getApiUrl(): string {
   const base = (import.meta as any).env?.PUBLIC_BACKEND_URL || 'http://localhost:3000/';
   return `${base.replace(/\/$/, '')}/api/spotify/now-playing`;
+}
+
+function extractTrackId(spotifyUrl: string): string | null {
+  return spotifyUrl.match(/\/track\/([A-Za-z0-9]+)/)?.[1] ?? null;
 }
 
 /* RAF-based bar visualizer — heights updated via refs (zero re-renders) */
@@ -105,11 +110,25 @@ export default function SpotifyChip() {
 
   const { track, playing } = data;
 
+  const handleClick = () => {
+    const trackId = track.spotifyUrl ? extractTrackId(track.spotifyUrl) : null;
+    if (trackId) {
+      usePlayerStore.getState().playTrack(trackId, {
+        id: trackId,
+        name: track.name,
+        artist: track.artist,
+        coverUrl: track.coverUrl ?? '',
+        spotifyUrl: track.spotifyUrl ?? undefined,
+      });
+    } else {
+      window.location.href = '/music/';
+    }
+  };
+
   return (
-    <a
-      href={track.spotifyUrl ?? '/music/'}
-      target={track.spotifyUrl ? '_blank' : undefined}
-      rel={track.spotifyUrl ? 'noopener noreferrer' : undefined}
+    <button
+      type="button"
+      onClick={handleClick}
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -121,6 +140,9 @@ export default function SpotifyChip() {
         textDecoration: 'none',
         transition: 'border-color 0.2s, transform 0.2s, box-shadow 0.2s',
         flexShrink: 0,
+        cursor: 'pointer',
+        textAlign: 'left',
+        fontFamily: 'inherit',
       }}
       onMouseEnter={(e) => {
         const el = e.currentTarget as HTMLElement;
@@ -206,6 +228,6 @@ export default function SpotifyChip() {
 
       {/* Visualizer */}
       <VisualizerBars playing={playing} />
-    </a>
+    </button>
   );
 }

--- a/frontend/src/components/music/PersistentPlayer.tsx
+++ b/frontend/src/components/music/PersistentPlayer.tsx
@@ -87,7 +87,7 @@ export function PersistentPlayer() {
   const embedWrapperRef = useRef<HTMLDivElement>(null);
   const playerContainerRef = useRef<HTMLDivElement>(null);
   const controllerRef = useRef<EmbedController | null>(null);
-  const lastPlaybackStartedAt = useRef(0);
+  const ignorePlaybackStateUntil = useRef(0);
   const dragRef = useRef<{ active: boolean; pending: boolean; startX: number; startY: number; startLeft: number; startTop: number; pointerId: number | null }>({ active: false, pending: false, startX: 0, startY: 0, startLeft: 0, startTop: 0, pointerId: null });
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [position, setPosition] = useState(0);
@@ -158,7 +158,8 @@ export function PersistentPlayer() {
           }
 
           EmbedController.addListener("playback_started", () => {
-            lastPlaybackStartedAt.current = Date.now();
+            // Ignorar eventos de Spotify por 4s tras iniciar pista (evita falsos isPaused)
+            ignorePlaybackStateUntil.current = Date.now() + 4000;
             setPlaying(true);
           });
 
@@ -167,9 +168,7 @@ export function PersistentPlayer() {
             const playingUri = (e.data as { playingURI?: string })?.playingURI;
             const isOurTrack = !tid || !playingUri || playingUri === `spotify:track:${tid}`;
             if (isOurTrack && e.data?.isPaused !== undefined) {
-              const recentlyStarted = Date.now() - lastPlaybackStartedAt.current < 4000;
-              // Ignorar isPaused: true en los ~4s tras playback_started (Spotify envía valores erróneos)
-              if (!e.data.isPaused || !recentlyStarted) {
+              if (Date.now() > ignorePlaybackStateUntil.current) {
                 setPlaying(!e.data.isPaused);
               }
             }
@@ -205,6 +204,8 @@ export function PersistentPlayer() {
     const ctrl = controllerRef.current;
     if (!ctrl || !isReady) return;
     const currentlyPlaying = usePlayerStore.getState().isPlaying;
+    // Bloquear eventos de Spotify 2s para que no sobreescriban el estado del usuario
+    ignorePlaybackStateUntil.current = Date.now() + 2000;
     if (currentlyPlaying) {
       ctrl.pause();
     } else {


### PR DESCRIPTION
## Summary

- **SpotifyChip**: el chip de música ya no abre Spotify en nueva pestaña — hace click y carga la canción en el reproductor flotante interno. Si no hay Spotify URL redirige a `/music/`.
- **Player play/pause**: eliminada race condition donde `playback_update` de Spotify sobreescribía el pause/play explícito del usuario en los primeros ~4s de una pista. Reemplazado el check `recentlyStarted` por un ref `ignorePlaybackStateUntil` que bloquea cambios de estado 4s tras `playback_started` y 2s tras cada acción del usuario.
- **Stats en 0**: añadido fetch client-side en `IntroPersonal.astro` como fallback cuando el SSR no alcanza el backend (dev sin backend, o prod antes de que esté listo `PUBLIC_BACKEND_URL_SSR`). La animación espera a que ambas condiciones se cumplan: fetch terminado + elemento en viewport.

## Test plan

- [ ] Hacer click en el chip de Spotify en la home → se abre el reproductor flotante (no Spotify)
- [ ] Iniciar una canción y pausar dentro de los primeros 3 segundos → el pause funciona correctamente
- [ ] Ver la sección "¡Hola! Soy Bryan Muñoz" → los contadores muestran los valores reales (no 0)
- [ ] Verificar que el reproductor flotante sigue funcionando normalmente (seek, minimizar, cerrar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)