### PR TITLE
refactor(frontend): limpiar TODOs y código muerto en Layout.astro

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -26,14 +26,13 @@ import { url, pathsEqual } from '../utils/url-utils'
 
 interface Props {
   title?: string
-  banner?: string
   description?: string
   lang?: string
   setOGTypeArticle?: boolean
   authPage?: boolean
 }
 
-let { title, banner, description, lang, setOGTypeArticle, authPage = false } = Astro.props
+let { title, description, lang, setOGTypeArticle, authPage = false } = Astro.props
 
 // apply a class to the body element to decide the height of the banner, only used for initial page load
 // Swup can update the body for each page visit, but it's after the page transition, causing a delay for banner height change
@@ -43,12 +42,6 @@ const isHomePage = pathsEqual(Astro.url.pathname, url('/'))
 // defines global css variables
 // why doing this in Layout instead of GlobalStyles: https://github.com/withastro/astro/issues/6728#issuecomment-1502203757
 const configHue = siteConfig.themeColor.hue
-if (!banner || typeof banner !== 'string' || banner.trim() === '') {
-  banner = siteConfig.banner.src
-}
-
-// TODO don't use post cover as banner for now
-banner = siteConfig.banner.src
 
 const enableBanner = siteConfig.banner.enable
 
@@ -271,37 +264,6 @@ import {
 // 	}
 // })();
 
-/* TODO This is a temporary solution for style flicker issue when the transition is activated */
-/* issue link: https://github.com/withastro/astro/issues/8711, the solution get from here too */
-/* update: fixed in Astro 3.2.4 */
-/*
-function disableAnimation() {
-	const css = document.createElement('style')
-	css.appendChild(
-		document.createTextNode(
-			`*{
-              -webkit-transition:none!important;
-              -moz-transition:none!important;
-              -o-transition:none!important;
-              -ms-transition:none!important;
-              transition:none!important
-              }`
-		)
-	)
-	document.head.appendChild(css)
-
-	return () => {
-		// Force restyle
-		;(() => window.getComputedStyle(document.body))()
-
-		// Wait for next tick before removing
-		setTimeout(() => {
-			document.head.removeChild(css)
-		}, 1)
-	}
-}
-*/
-
 const bannerEnabled = !!document.getElementById('banner-wrapper')
 
 function setClickOutsideToClose(panel: string, ignores: string[]) {
@@ -372,7 +334,6 @@ function showBanner() {
 }
 
 function init() {
-	// disableAnimation()()		// TODO
 	loadTheme();
 	loadHue();
 	initCustomScrollbar();
@@ -424,18 +385,6 @@ document.addEventListener('astro:after-swap', () => {
 });
 
 const setup = () => {
-	// TODO: temp solution to change the height of the banner
-/*
-	window.swup.hooks.on('animation:out:start', () => {
-		const path = window.location.pathname
-		const body = document.querySelector('body')
-		if (path[path.length - 1] === '/' && !body.classList.contains('is-home')) {
-			body.classList.add('is-home')
-		} else if (path[path.length - 1] !== '/' && body.classList.contains('is-home')) {
-			body.classList.remove('is-home')
-		}
-	})
-*/
 	window.swup.hooks.on('link:click', () => {
 		// Remove the delay for the first time page load
 		document.documentElement.style.setProperty('--content-delay', '0ms')

--- a/frontend/src/layouts/MainGridLayout.astro
+++ b/frontend/src/layouts/MainGridLayout.astro
@@ -13,7 +13,6 @@ const hasBannerCredit =
 
   interface Props {
   title?: string
-  banner?: string
   description?: string
   lang?: string
   setOGTypeArticle?: boolean;
@@ -25,7 +24,7 @@ const hasBannerCredit =
   hideSidebar?: boolean
 }
 
-const { title, banner, description, lang, setOGTypeArticle, headings = [], showProfile, showCategories, showTags, showArchiveLink, hideSidebar = false } = Astro.props
+const { title, description, lang, setOGTypeArticle, headings = [], showProfile, showCategories, showTags, showArchiveLink, hideSidebar = false } = Astro.props
 ---
 
 <MainLayout>

--- a/frontend/src/layouts/MainLayout.astro
+++ b/frontend/src/layouts/MainLayout.astro
@@ -11,21 +11,20 @@ import {BANNER_HEIGHT, BANNER_HEIGHT_EXTEND, MAIN_PANEL_OVERLAPS_BANNER_HEIGHT} 
 
 interface Props {
   title?: string
-  banner?: string
   description?: string
   lang?: string
   setOGTypeArticle?: boolean;
   headings? : MarkdownHeading[]
 }
 
-const { title, banner, description, lang, setOGTypeArticle, headings = [] } = Astro.props
+const { title, description, lang, setOGTypeArticle, headings = [] } = Astro.props
 
 
 
 const mainPanelTop = siteConfig.banner.enable ? `calc(${BANNER_HEIGHT}vh - ${MAIN_PANEL_OVERLAPS_BANNER_HEIGHT}rem)` : "5.5rem"
 ---
 
-<Layout title={title} banner={banner} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle}>
+<Layout title={title} description={description} lang={lang} setOGTypeArticle={setOGTypeArticle}>
 
 <!-- Navbar -->
 <slot slot="head" name="head"></slot>

--- a/frontend/src/pages/posts/[...slug].astro
+++ b/frontend/src/pages/posts/[...slug].astro
@@ -48,7 +48,7 @@ const jsonLd = {
   // TODO include cover image here
 }
 ---
-<MainGridLayout banner={entry.image} title={entry.title} description={entry.description} lang={entry.language} setOGTypeArticle={true} hideSidebar={true}>
+<MainGridLayout title={entry.title} description={entry.description} lang={entry.language} setOGTypeArticle={true} hideSidebar={true}>
     <script is:inline slot="head" type="application/ld+json" set:html={JSON.stringify(jsonLd)}></script>
     <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative mb-4">
         <div id="post-container" class:list={["card-base z-10 px-6 md:px-9 pt-6 pb-4 relative w-full ",{}]}>


### PR DESCRIPTION
## Summary
- Elimina `disableAnimation()` (workaround comentado para flicker de transición; el propio comentario indica "fixed in Astro 3.2.4" — el proyecto está en Astro ^5.12.1)
- Elimina el bloque comentado `animation:out:start` que togglea `is-home`; quedó superseded por el hook activo `visit:start` que ya maneja `lg:is-home` y más casos (auth pages, TOC, etc.)
- Elimina la cadena completa del prop `banner` (TODO "don't use post cover as banner for now"): se rastreó desde `posts/[...slug].astro` → `MainGridLayout` → `MainLayout` → `Layout`, y en ningún punto se usaba para renderizar — `MainLayout.astro` siempre pinta `siteConfig.banner.src` hardcodeado. Cero cambio visual, puro código muerto.

## Test plan
- [x] `pnpm astro check` — sin errores nuevos en los 4 archivos tocados (los 19 errores reportados son preexistentes en otros archivos: admin/tags, gallery, test)
- [ ] Verificar visualmente que el banner se sigue viendo igual en home y en posts